### PR TITLE
Release v1.0.0

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -54,12 +54,23 @@ jobs:
             echo "WARNING: pyproject.toml version ($FILE_VERSION) does not match tag (${{ steps.version.outputs.version }})" >&2
           fi
 
+      - name: Read SDK version from pyproject
+        id: sdk
+        run: |
+          SDK_VERSION=$(python - <<'PY'
+          import tomllib, pathlib
+          d = tomllib.loads(pathlib.Path('pyproject.toml').read_text('utf-8'))
+          print(d['tool']['aic-sdk']['sdk-version'])
+          PY
+          )
+          echo "sdk_version=$SDK_VERSION" >> $GITHUB_OUTPUT
+
       - name: Download platform SDK assets from private repo
         env:
           GH_TOKEN: ${{ secrets.AIC_SDK_ACCESS_TOKEN }}
         run: |
           set -euo pipefail
-          VERSION='${{ steps.version.outputs.base_version }}'
+          VERSION='${{ steps.sdk.outputs.sdk_version }}'
           mkdir -p release-assets
           echo "Available releases in private repo (top 10):"
           gh release list --repo ai-coustics/aic-sdk --limit 10 || true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.9
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+

--- a/LICENSE.AIC-SDK
+++ b/LICENSE.AIC-SDK
@@ -7,7 +7,7 @@ Copyright © 2025 ai-coustics GmbH. All rights reserved.
            aic/libs/* (e.g. libaic.so, libaic.dylib, aic.dll) together with
            the public C headers aic.h and aic_c.h.
     “Wrapper” means the Python source code in this repository that links to
-               the SDK.  The Wrapper is licensed separately under the MIT
+               the SDK.  The Wrapper is licensed separately under the Apache 2.0
                license found in LICENSE.
     “You”     means the individual or legal entity exercising rights under
                this Agreement.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ The SDK requires a license key for full functionality.
    load_dotenv()  # loads .env if present
    license_key = os.getenv("AICOUSTICS_API_KEY")
 
-   with Model(AICModelType.QUAIL_L, license_key=license_key) as model:
-       model.initialize(sample_rate=48000, channels=1, frames=480)
+   with Model(AICModelType.QUAIL_L, license_key=license_key, sample_rate=48000, channels=1, frames=480) as model:
        # ...
    ```
 
@@ -80,10 +79,10 @@ license_key = os.getenv("AICOUSTICS_API_KEY")
 model = Model(
     model_type=AICModelType.QUAIL_L,
     license_key=license_key,   # pass the key from env (empty = trial)
+    sample_rate=48000,
+    channels=1,
+    frames=480,
 )
-
-# Initialize for 48kHz mono audio with 480-frame buffers
-model.initialize(sample_rate=48000, channels=1, frames=480)
 
 # Set enhancement strength (0.0 to 1.0)
 model.set_parameter(AICParameter.ENHANCEMENT_LEVEL, 0.8)
@@ -107,8 +106,7 @@ from aic import Model, AICModelType
 load_dotenv()
 license_key = os.getenv("AICOUSTICS_API_KEY", "")
 
-with Model(AICModelType.QUAIL_L, license_key=license_key) as model:
-    model.initialize(sample_rate=48000, channels=1, frames=480)
+with Model(AICModelType.QUAIL_L, license_key=license_key, sample_rate=48000, channels=1, frames=480) as model:
     # Process audio in chunks
     audio_chunk = np.random.randn(1, 480).astype(np.float32)
     enhanced = model.process(audio_chunk)
@@ -142,8 +140,7 @@ def enhance_wav_file(input_path, output_path, strength=80):
     load_dotenv()
     license_key = os.getenv("AICOUSTICS_API_KEY")
 
-    with Model(AICModelType.QUAIL_L, license_key=license_key) as model:
-        model.initialize(sample_rate=48000, channels=1, frames=480)
+    with Model(AICModelType.QUAIL_L, license_key=license_key, sample_rate=48000, channels=1, frames=480) as model:
         model.set_parameter(AICParameter.ENHANCEMENT_LEVEL, strength / 100)
         
         # Process in chunks
@@ -185,8 +182,7 @@ For the complete, up-to-date API documentation (including class/method docs and 
 ### Real-time Streaming
 
 ```python
-with Model(AICModelType.QUAIL_S) as model:
-    model.initialize(sample_rate=48000, channels=1, frames=480)
+with Model(AICModelType.QUAIL_S, sample_rate=48000, channels=1, frames=480) as model:
     
     while audio_stream.has_data():
         chunk = audio_stream.get_chunk(480)  # Get 480 frames
@@ -197,14 +193,76 @@ with Model(AICModelType.QUAIL_S) as model:
 ### Batch Processing
 
 ```python
-with Model(AICModelType.QUAIL_L) as model:
-    model.initialize(sample_rate=48000, channels=1, frames=480)
+with Model(AICModelType.QUAIL_L, sample_rate=48000, channels=1, frames=480) as model:
     
     for audio_file in audio_files:
         audio = load_audio(audio_file)
         enhanced = process_in_chunks(model, audio)
         save_audio(enhanced, f"enhanced_{audio_file}")
 ```
+
+## 🧑‍💻 Development
+
+### Setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+pip install -r requirements-dev.txt  # includes editable install (-e .)
+```
+
+### Pre-commit hooks (Ruff)
+
+```bash
+pre-commit install
+pre-commit run --all-files
+```
+
+This runs Ruff linting and formatting on commit. You can also run Ruff manually:
+
+```bash
+ruff check . --fix
+ruff format .
+```
+
+### Running tests
+
+- Unit tests (no native SDK required):
+
+```bash
+pytest -q
+```
+
+- Integration tests (real SDK + license required):
+
+```bash
+export AICOUSTICS_API_KEY="your_key"  # or use a .env file
+pytest -q integration_tests
+```
+
+Note: To run against the real native SDK locally, it is simplest to install the package non-editable so the platform binaries are bundled:
+
+```bash
+pip uninstall -y aic-sdk
+pip install .
+```
+
+Editable installs (`-e .`) do not place native binaries into the source tree. The unit test suite does not need them; the integration suite does.
+
+### Docs (MkDocs)
+
+```bash
+mkdocs serve   # live-reload docs at http://127.0.0.1:8000
+# or
+mkdocs build
+```
+
+### Versioning
+
+- Python wrapper version: `pyproject.toml` → `[project].version`
+- C SDK binary version: `pyproject.toml` → `[tool.aic-sdk].sdk-version`
+
+The Python version and the underlying C SDK version are intentionally decoupled. The build step downloads platform binaries named from `sdk-version`.
 
 ## 🐛 Troubleshooting
 

--- a/aic/_bindings.py
+++ b/aic/_bindings.py
@@ -3,11 +3,12 @@
 This module provides a thin, typed layer over the C API exposed by the SDK.
 Most users should prefer the higher-level :pyclass:`aic.Model` wrapper.
 """
+
 from __future__ import annotations
 
 import ctypes as _ct
 from enum import IntEnum
-from typing import Any, Optional
+from typing import Any
 
 from ._loader import load
 
@@ -15,47 +16,107 @@ from ._loader import load
 #  Automatically extracted enums – edit in aic/_generate_bindings.py instead  #
 ################################################################################
 
+
 class AICErrorCode(IntEnum):
-    """Error codes returned by the C API."""
-    SUCCESS                   = 0
+    """Error codes returned by the C API.
+
+    These mirror the values from the underlying SDK and are raised as
+    ``RuntimeError`` by the thin wrappers in this module when a call
+    does not succeed.
+    """
+
+    SUCCESS = 0
     """Operation completed successfully."""
 
-    NULL_POINTER              = 1
-    """A null pointer was passed to the C API."""
+    NULL_POINTER = 1
+    """Required pointer argument was NULL."""
 
-    LICENSE_INVALID           = 2
-    """The provided license string is invalid."""
+    LICENSE_INVALID = 2
+    """License key format is invalid or corrupted."""
 
-    LICENSE_EXPIRED           = 3
-    """The provided license has expired."""
+    LICENSE_EXPIRED = 3
+    """License key has expired."""
 
-    UNSUPPORTED_AUDIO_CONFIG  = 4
-    """Requested sample rate, channels, or buffer size is unsupported."""
+    UNSUPPORTED_AUDIO_CONFIG = 4
+    """Audio configuration is not supported by the model."""
 
-    AUDIO_CONFIG_MISMATCH     = 5
-    """Processing call used settings different from initialization."""
+    AUDIO_CONFIG_MISMATCH = 5
+    """Process was called with a different audio buffer configuration than initialized."""
 
-    NOT_INITIALIZED           = 6
-    """Model was used before it was initialized."""
+    NOT_INITIALIZED = 6
+    """Model must be initialized before this operation."""
 
-    PARAMETER_OUT_OF_RANGE    = 7
-    """A parameter value was outside its valid range."""
+    PARAMETER_OUT_OF_RANGE = 7
+    """Parameter value is outside acceptable range."""
 
-    SDK_ACTIVATION_ERROR      = 8
+    SDK_ACTIVATION_ERROR = 8
     """SDK activation failed."""
 
 
 class AICModelType(IntEnum):
-    """Available neural model variants."""
+    """Available model types for audio enhancement.
+
+    Each model is optimized for a native sample rate and frame size and has
+    a characteristic processing latency.
+    """
+
     # Detailed variants with native rates and frame sizes
-    QUAIL_L48  = 0
-    QUAIL_L16  = 1
-    QUAIL_L8   = 2
-    QUAIL_S48  = 3
-    QUAIL_S16  = 4
-    QUAIL_S8   = 5
-    QUAIL_XS   = 6
-    QUAIL_XXS  = 7
+    QUAIL_L48 = 0
+    """Specifications:
+
+    - Native sample rate: 48 kHz
+    - Native num frames: 480
+    - Processing latency: 30 ms
+    """
+    QUAIL_L16 = 1
+    """Specifications:
+
+    - Native sample rate: 16 kHz
+    - Native num frames: 160
+    - Processing latency: 30 ms
+    """
+    QUAIL_L8 = 2
+    """Specifications:
+
+    - Native sample rate: 8 kHz
+    - Native num frames: 80
+    - Processing latency: 30 ms
+    """
+    QUAIL_S48 = 3
+    """Specifications:
+
+    - Native sample rate: 48 kHz
+    - Native num frames: 480
+    - Processing latency: 30 ms
+    """
+    QUAIL_S16 = 4
+    """Specifications:
+
+    - Native sample rate: 16 kHz
+    - Native num frames: 160
+    - Processing latency: 30 ms
+    """
+    QUAIL_S8 = 5
+    """Specifications:
+
+    - Native sample rate: 8 kHz
+    - Native num frames: 80
+    - Processing latency: 30 ms
+    """
+    QUAIL_XS = 6
+    """Specifications:
+
+    - Native sample rate: 48 kHz
+    - Native num frames: 480
+    - Processing latency: 10 ms
+    """
+    QUAIL_XXS = 7
+    """Specifications:
+
+    - Native sample rate: 48 kHz
+    - Native num frames: 480
+    - Processing latency: 10 ms
+    """
 
     # Backwards-compatible aliases
     QUAIL_L = 0
@@ -63,24 +124,55 @@ class AICModelType(IntEnum):
 
 
 class AICParameter(IntEnum):
-    """Algorithm parameters adjustable at runtime."""
-    ENHANCEMENT_LEVEL                     = 0
-    """Overall enhancement strength (0.0 … 1.0)."""
+    """Configurable parameters for audio enhancement."""
 
-    VOICE_GAIN                            = 1
-    """Additional gain applied to detected speech (linear)."""
+    ENHANCEMENT_LEVEL = 0
+    """Controls the intensity of speech enhancement processing.
 
-    NOISE_GATE_ENABLE                     = 2
-    """Enable/disable noise gate (0.0 off → 1.0 on)."""
+    Range: 0.0 … 1.0
+
+    - 0.0: Bypass (original signal passes through unchanged)
+    - 1.0: Full enhancement (maximum noise reduction, potentially more artifacts)
+
+    Default: 1.0
+    """
+
+    VOICE_GAIN = 1
+    """Compensates for perceived volume reduction after noise removal.
+
+    Range: 0.1 … 4.0 (linear amplitude multiplier)
+
+    - 0.1: Significant volume reduction (≈ −20 dB)
+    - 1.0: No gain change (0 dB, default)
+    - 2.0: Double amplitude (+6 dB)
+    - 4.0: Maximum boost (+12 dB)
+
+    Formula: gain_dB = 20 × log10(value)
+    Default: 1.0
+    """
+
+    NOISE_GATE_ENABLE = 2
+    """Enable or disable a noise gate as a pre-processing step.
+
+    Valid values: 0.0 or 1.0
+
+    - 0.0: Noise gate disabled (C library default)
+    - 1.0: Noise gate enabled
+
+    Default: 0.0
+    """
+
 
 ################################################################################
 #                       struct forward declarations                             #
 ################################################################################
 
+
 class _AICModel(_ct.Structure):
     pass
 
-AICModelPtr  = _ct.POINTER(_AICModel)
+
+AICModelPtr = _ct.POINTER(_AICModel)
 # Alias for annotations to satisfy static type checkers (no TypeAlias to support py3.9)
 AICModelPtrT = Any
 
@@ -88,7 +180,7 @@ AICModelPtrT = Any
 #                       function prototypes                                     #
 ################################################################################
 
-_LIB: Optional[_ct.CDLL] = None
+_LIB: _ct.CDLL | None = None
 _PROTOTYPES_CONFIGURED = False
 
 
@@ -100,33 +192,33 @@ def _get_lib() -> _ct.CDLL:
     if not _PROTOTYPES_CONFIGURED:
         lib = _LIB
         # function prototypes
-        lib.aic_model_create.restype  = AICErrorCode
+        lib.aic_model_create.restype = AICErrorCode
         lib.aic_model_create.argtypes = [
             _ct.POINTER(AICModelPtr),  # **model
-            _ct.c_int,                 # model_type (AICModelType)
-            _ct.c_char_p,              # license_key
+            _ct.c_int,  # model_type (AICModelType)
+            _ct.c_char_p,  # license_key
         ]
 
-        lib.aic_model_destroy.restype  = None
+        lib.aic_model_destroy.restype = None
         lib.aic_model_destroy.argtypes = [AICModelPtr]
 
-        lib.aic_model_initialize.restype  = AICErrorCode
+        lib.aic_model_initialize.restype = AICErrorCode
         lib.aic_model_initialize.argtypes = [
             AICModelPtr,
-            _ct.c_uint32,   # sample_rate
-            _ct.c_uint16,   # num_channels
-            _ct.c_size_t,   # num_frames
+            _ct.c_uint32,  # sample_rate
+            _ct.c_uint16,  # num_channels
+            _ct.c_size_t,  # num_frames
         ]
 
-        lib.aic_model_reset.restype  = AICErrorCode
+        lib.aic_model_reset.restype = AICErrorCode
         lib.aic_model_reset.argtypes = [AICModelPtr]
 
         lib.aic_model_process_planar.restype = AICErrorCode
         lib.aic_model_process_planar.argtypes = [
             AICModelPtr,
             _ct.POINTER(_ct.POINTER(_ct.c_float)),  # float* const* audio
-            _ct.c_uint16,                           # num_channels
-            _ct.c_size_t,                           # num_frames
+            _ct.c_uint16,  # num_channels
+            _ct.c_size_t,  # num_frames
         ]
 
         lib.aic_model_process_interleaved.restype = AICErrorCode
@@ -137,42 +229,42 @@ def _get_lib() -> _ct.CDLL:
             _ct.c_size_t,
         ]
 
-        lib.aic_model_set_parameter.restype  = AICErrorCode
+        lib.aic_model_set_parameter.restype = AICErrorCode
         lib.aic_model_set_parameter.argtypes = [
             AICModelPtr,
-            _ct.c_int,                 # parameter (AICParameter)
+            _ct.c_int,  # parameter (AICParameter)
             _ct.c_float,
         ]
 
-        lib.aic_model_get_parameter.restype  = AICErrorCode
+        lib.aic_model_get_parameter.restype = AICErrorCode
         lib.aic_model_get_parameter.argtypes = [
             AICModelPtr,
-            _ct.c_int,                 # parameter (AICParameter)
+            _ct.c_int,  # parameter (AICParameter)
             _ct.POINTER(_ct.c_float),
         ]
 
         # delay API (new in >=0.6.0, fallback to old symbol when running older libs)
         if hasattr(lib, "aic_get_output_delay"):
-            lib.aic_get_output_delay.restype  = AICErrorCode
+            lib.aic_get_output_delay.restype = AICErrorCode
             lib.aic_get_output_delay.argtypes = [
                 AICModelPtr,
                 _ct.POINTER(_ct.c_size_t),
             ]
         else:
-            lib.aic_get_processing_latency = getattr(lib, "aic_get_processing_latency")  # type: ignore[attr-defined]
-            lib.aic_get_processing_latency.restype  = AICErrorCode
+            lib.aic_get_processing_latency = lib.aic_get_processing_latency  # type: ignore[attr-defined]
+            lib.aic_get_processing_latency.restype = AICErrorCode
             lib.aic_get_processing_latency.argtypes = [
                 AICModelPtr,
                 _ct.POINTER(_ct.c_size_t),
             ]
 
-        lib.aic_get_optimal_sample_rate.restype  = AICErrorCode
+        lib.aic_get_optimal_sample_rate.restype = AICErrorCode
         lib.aic_get_optimal_sample_rate.argtypes = [
             AICModelPtr,
             _ct.POINTER(_ct.c_uint32),
         ]
 
-        lib.aic_get_optimal_num_frames.restype  = AICErrorCode
+        lib.aic_get_optimal_num_frames.restype = AICErrorCode
         lib.aic_get_optimal_num_frames.argtypes = [
             AICModelPtr,
             _ct.POINTER(_ct.c_size_t),
@@ -188,74 +280,249 @@ def _get_lib() -> _ct.CDLL:
         _PROTOTYPES_CONFIGURED = True
     return _LIB
 
+
 ################################################################################
 #                     thin pythonic convenience wrappers                        #
 ################################################################################
 
-def model_create(model_type: AICModelType, license_key: bytes) -> AICModelPtrT:  
-    """Create a model instance and return an opaque handle.
+
+def model_create(model_type: AICModelType, license_key: bytes) -> AICModelPtrT:
+    """Create a new audio enhancement model instance.
+
+    Multiple models can be created to process different audio streams
+    simultaneously or to switch between enhancement algorithms.
+
+    Parameters
+    ----------
+    model_type : AICModelType
+        Selects the enhancement algorithm variant.
+    license_key : bytes
+        Null-terminated license string. Must not be empty.
+
+    Returns
+    -------
+    AICModelPtrT
+        Opaque handle to the created model instance.
 
     Raises
     ------
     RuntimeError
-        If the underlying C call fails.
+        If the underlying C call fails. The error message includes
+        the corresponding :class:`AICErrorCode` name from the SDK.
+
     """
     lib = _get_lib()
     mdl = AICModelPtr()
-    err = lib.aic_model_create(
-        _ct.byref(mdl), model_type, license_key  
-    )
+    err = lib.aic_model_create(_ct.byref(mdl), model_type, license_key)
     _raise(err)
     return mdl
 
+
 def model_destroy(model: AICModelPtrT) -> None:
-    """Destroy a model handle (idempotent)."""
+    """Release all resources associated with a model instance.
+
+    Safe to call with a null/invalid handle; the operation is idempotent.
+
+    Parameters
+    ----------
+    model : AICModelPtrT
+        Model instance to destroy. Can be ``None``.
+
+    Returns
+    -------
+    None
+
+    """
     lib = _get_lib()
     lib.aic_model_destroy(model)
 
-def model_initialize(model: AICModelPtrT, sample_rate: int,
-                     num_channels: int, num_frames: int) -> None:
-    """Initialize a model for the given I/O configuration."""
-    lib = _get_lib()
-    _raise(lib.aic_model_initialize(model, sample_rate, num_channels, num_frames))
 
-def model_reset(model: AICModelPtrT) -> None:
-    """Reset internal state (flush history)."""
-    lib = _get_lib()
-    _raise(lib.aic_model_reset(model))
+def model_initialize(model: AICModelPtrT, sample_rate: int, num_channels: int, num_frames: int) -> None:
+    """Configure the model for a specific audio format.
 
-def process_planar(model: AICModelPtrT, audio_ptr: Any, num_channels: int,
-                   num_frames: int) -> None:
-    """Process planar audio in-place.
+    Must be called before processing. For the lowest delay use the values
+    returned by :func:`get_optimal_sample_rate` and
+    :func:`get_optimal_num_frames`.
+
+    Parameters
+    ----------
+    model : AICModelPtrT
+        Model handle. Must not be ``None``.
+    sample_rate : int
+        Audio sample rate in Hz (8000–192000).
+    num_channels : int
+        Number of audio channels (1 for mono, 2 for stereo, etc.).
+    num_frames : int
+        Number of samples per channel per processing call.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    RuntimeError
+        If the configuration is not supported by the model.
 
     Notes
     -----
-    The C side expects a pointer-to-pointer array with one pointer per channel.
+    Not real-time safe: do not call from time-critical audio threads.
+
+    """
+    lib = _get_lib()
+    _raise(lib.aic_model_initialize(model, sample_rate, num_channels, num_frames))
+
+
+def model_reset(model: AICModelPtrT) -> None:
+    """Clear all internal state and buffers (real-time safe).
+
+    Call this when the audio stream is interrupted or when seeking to
+    prevent artifacts from previous audio content. The model remains
+    initialized with the same configuration.
+
+    Parameters
+    ----------
+    model : AICModelPtrT
+        Model instance. Must not be ``None``.
+
+    Returns
+    -------
+    None
+
+    """
+    lib = _get_lib()
+    _raise(lib.aic_model_reset(model))
+
+
+def process_planar(model: AICModelPtrT, audio_ptr: Any, num_channels: int, num_frames: int) -> None:
+    """Process audio in-place with separate buffers per channel (planar layout).
+
+    Parameters
+    ----------
+    model : AICModelPtrT
+        Initialized model instance.
+    audio_ptr : Any
+        Array of channel buffer pointers (``float* const*`` on the C side).
+    num_channels : int
+        Number of channels (must match initialization; max 16 channels).
+    num_frames : int
+        Number of samples per channel (must match initialization).
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    RuntimeError
+        If the model is not initialized, inputs are null, or the channel/frame
+        configuration does not match the initialization.
+
     """
     lib = _get_lib()
     _raise(lib.aic_model_process_planar(model, audio_ptr, num_channels, num_frames))
 
-def process_interleaved(model: AICModelPtrT, audio_ptr: Any, num_channels: int,
-                        num_frames: int) -> None:
-    """Process interleaved audio in-place."""
+
+def process_interleaved(model: AICModelPtrT, audio_ptr: Any, num_channels: int, num_frames: int) -> None:
+    """Process audio in-place with interleaved channel data.
+
+    Parameters
+    ----------
+    model : AICModelPtrT
+        Initialized model instance.
+    audio_ptr : Any
+        Interleaved audio buffer pointer.
+    num_channels : int
+        Number of channels (must match initialization).
+    num_frames : int
+        Number of frames per channel (must match initialization).
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    RuntimeError
+        If the model is not initialized, inputs are null, or the channel/frame
+        configuration does not match the initialization.
+
+    """
     lib = _get_lib()
     _raise(lib.aic_model_process_interleaved(model, audio_ptr, num_channels, num_frames))
 
-def set_parameter(model: AICModelPtrT, param: AICParameter,
-                  value: float) -> None:
-    """Set an algorithm parameter."""
+
+def set_parameter(model: AICModelPtrT, param: AICParameter, value: float) -> None:
+    """Modify a model parameter (thread-safe).
+
+    Parameters
+    ----------
+    model : AICModelPtrT
+        Model instance. Must not be ``None``.
+    param : AICParameter
+        Parameter to modify.
+    value : float
+        New parameter value. See parameter docs for valid ranges.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    RuntimeError
+        If the value is outside the acceptable range.
+
+    """
     lib = _get_lib()
     _raise(lib.aic_model_set_parameter(model, param, value))
 
+
 def get_parameter(model: AICModelPtrT, param: AICParameter) -> float:
-    """Get the current value of an algorithm parameter."""
+    """Retrieve the current value of a parameter (thread-safe).
+
+    Parameters
+    ----------
+    model : AICModelPtrT
+        Model instance. Must not be ``None``.
+    param : AICParameter
+        Parameter to query.
+
+    Returns
+    -------
+    float
+        The current value of the parameter.
+
+    """
     lib = _get_lib()
     out = _ct.c_float()
     _raise(lib.aic_model_get_parameter(model, param, _ct.byref(out)))
     return float(out.value)
 
+
 def get_processing_latency(model: AICModelPtrT) -> int:
-    """Return output delay in samples (back-compat wrapper)."""
+    """Return total output delay in samples for the current configuration.
+
+    Delay behavior
+    --------------
+    - Before initialization: returns the base processing delay using the
+      model's optimal frame size at its native sample rate.
+    - After initialization: returns the actual delay for the configured
+      sample rate and frame size, including any additional buffering when
+      using non-optimal frame sizes.
+
+    Parameters
+    ----------
+    model : AICModelPtrT
+        Model instance. Must not be ``None``.
+
+    Returns
+    -------
+    int
+        Delay in samples (at the current sample rate). Convert to milliseconds
+        via ``delay_ms = delay_samples * 1000 / sample_rate``.
+
+    """
     lib = _get_lib()
     out = _ct.c_size_t()
     if hasattr(lib, "aic_get_output_delay"):
@@ -264,32 +531,92 @@ def get_processing_latency(model: AICModelPtrT) -> int:
         _raise(lib.aic_get_processing_latency(model, _ct.byref(out)))  # type: ignore[attr-defined]
     return int(out.value)
 
+
 def get_output_delay(model: AICModelPtrT) -> int:
-    """Return output delay in samples."""
+    """Alias of :func:`get_processing_latency`.
+
+    Parameters
+    ----------
+    model : AICModelPtrT
+        Model instance.
+
+    Returns
+    -------
+    int
+        Delay in samples.
+
+    """
     return get_processing_latency(model)
 
+
 def get_optimal_sample_rate(model: AICModelPtrT) -> int:
-    """Return suggested sample rate in Hz."""
+    """Return the model's native sample rate in Hz.
+
+    Each model is optimized for a specific sample rate. While processing at
+    other rates is supported, enhancement quality for high frequencies is
+    bounded by the model's native Nyquist frequency.
+
+    Parameters
+    ----------
+    model : AICModelPtrT
+        Model instance.
+
+    Returns
+    -------
+    int
+        Native/optimal sample rate in Hz.
+
+    """
     lib = _get_lib()
     out = _ct.c_uint32()
     _raise(lib.aic_get_optimal_sample_rate(model, _ct.byref(out)))
     return int(out.value)
 
+
 def get_optimal_num_frames(model: AICModelPtrT) -> int:
-    """Return suggested buffer size in frames."""
+    """Return the optimal number of frames for minimal latency.
+
+    Using the optimal frame size avoids internal buffering and thus minimizes
+    end-to-end delay. The optimal value depends on sample rate and updates
+    when the model is initialized with a different rate. Before initialization
+    this returns the optimal size for the model's native sample rate.
+
+    Parameters
+    ----------
+    model : AICModelPtrT
+        Model instance.
+
+    Returns
+    -------
+    int
+        Optimal frame count for the current/native sample rate.
+
+    """
     lib = _get_lib()
     out = _ct.c_size_t()
     _raise(lib.aic_get_optimal_num_frames(model, _ct.byref(out)))
     return int(out.value)
 
+
 def get_library_version() -> str:
-    """Return SDK version string."""
+    """Return the SDK version string.
+
+    The returned value originates from a static C string and is safe to use
+    for the lifetime of the program.
+
+    Returns
+    -------
+    str
+        Semantic version string, for example ``"1.2.3"``.
+
+    """
     lib = _get_lib()
     if hasattr(lib, "aic_get_sdk_version"):
         version_ptr = lib.aic_get_sdk_version()  # type: ignore[attr-defined]
     else:
         version_ptr = lib.get_library_version()  # type: ignore[attr-defined]
-    return version_ptr.decode('utf-8')
+    return version_ptr.decode("utf-8")
+
 
 # ------------------------------------------------------------------#
 def _raise(err: AICErrorCode) -> None:

--- a/aic/_loader.py
+++ b/aic/_loader.py
@@ -3,6 +3,7 @@
 This module resolves the correct shared object packaged within the wheel and
 returns a loaded :class:`ctypes.CDLL` for use by the low-level bindings.
 """
+
 from __future__ import annotations
 
 import ctypes
@@ -11,10 +12,11 @@ import platform
 from pathlib import Path
 
 _PLAT = {
-    "Linux":   ("libaic.so",   "linux"),
-    "Darwin":  ("libaic.dylib","mac"),
-    "Windows": ("aic.dll",     "windows"),
+    "Linux": ("libaic.so", "linux"),
+    "Darwin": ("libaic.dylib", "mac"),
+    "Windows": ("aic.dll", "windows"),
 }
+
 
 def _path() -> Path:
     """Return the filesystem path to the packaged SDK shared library.
@@ -28,6 +30,7 @@ def _path() -> Path:
     ------
     RuntimeError
         If the current operating system is not supported.
+
     """
     sysname = platform.system()
     try:
@@ -39,6 +42,7 @@ def _path() -> Path:
     with res.path(pkg, libname) as p:
         return p
 
+
 def load() -> ctypes.CDLL:
     """Load and return the SDK shared library as a :class:`ctypes.CDLL`.
 
@@ -46,5 +50,6 @@ def load() -> ctypes.CDLL:
     -------
     ctypes.CDLL
         Ready-to-use handle for calling C functions.
+
     """
     return ctypes.CDLL(str(_path()))

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,29 @@
 # API Reference
 
+## Model Class
+
 ::: aic.Model
+    options:
+      show_root_heading: true
+      heading_level: 2
+      show_object_full_path: false
+
+## Enums
+
+::: aic._bindings.AICErrorCode
+    options:
+      show_root_heading: true
+      heading_level: 2
+      show_object_full_path: false
 
 ::: aic._bindings.AICModelType
+    options:
+      show_root_heading: true
+      heading_level: 2
+      show_object_full_path: false
 
 ::: aic._bindings.AICParameter
+    options:
+      show_root_heading: true
+      heading_level: 2
+      show_object_full_path: false

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,8 +12,7 @@ AICOUSTICS_API_KEY=your_key_here python examples/enhance.py input.wav output.wav
 import numpy as np
 from aic import Model, AICModelType
 
-with Model(AICModelType.QUAIL_S) as model:
-    model.initialize(sample_rate=48000, channels=1, frames=480)
+with Model(AICModelType.QUAIL_S, sample_rate=48000, channels=1, frames=480) as model:
 
     audio_stream = ...  # your audio input
     while audio_stream.has_data():

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,8 +35,7 @@ from aic import Model, AICModelType, AICParameter
 load_dotenv()
 license_key = os.getenv("AICOUSTICS_API_KEY")
 
-with Model(AICModelType.QUAIL_L, license_key=license_key) as model:
-    model.initialize(sample_rate=48000, channels=1, frames=480)
+with Model(AICModelType.QUAIL_L, license_key=license_key, sample_rate=48000, channels=1, frames=480) as model:
     model.set_parameter(AICParameter.ENHANCEMENT_LEVEL, 0.7)
 
     audio = np.random.randn(1, 480).astype(np.float32)

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,8 +23,7 @@ from aic import Model, AICModelType, AICParameter
 load_dotenv()
 license_key = os.getenv("AICOUSTICS_API_KEY", "")
 
-with Model(AICModelType.QUAIL_L, license_key=license_key) as model:
-    model.initialize(sample_rate=48000, channels=1, frames=480)
+with Model(AICModelType.QUAIL_L, license_key=license_key, sample_rate=48000, channels=1, frames=480) as model:
     model.set_parameter(AICParameter.ENHANCEMENT_LEVEL, 0.8)
 
     audio = np.random.randn(1, 480).astype(np.float32)

--- a/docs/low-level-bindings.md
+++ b/docs/low-level-bindings.md
@@ -1,0 +1,109 @@
+# Low-level C bindings (`aic._bindings`)
+
+The high-level `aic.Model` API is recommended for most applications. The low-level bindings mirror the C API and are useful for advanced integrations, benchmarks, or when you need fine-grained control.
+
+## Core functions
+
+::: aic._bindings.model_create
+    options:
+      show_root_heading: true
+      heading_level: 3
+      show_object_full_path: false
+
+::: aic._bindings.model_destroy
+    options:
+      show_root_heading: true
+      heading_level: 3
+      show_object_full_path: false
+
+::: aic._bindings.model_initialize
+    options:
+      show_root_heading: true
+      heading_level: 3
+      show_object_full_path: false
+
+::: aic._bindings.model_reset
+    options:
+      show_root_heading: true
+      heading_level: 3
+      show_object_full_path: false
+
+## Processing
+
+::: aic._bindings.process_planar
+    options:
+      show_root_heading: true
+      heading_level: 3
+      show_object_full_path: false
+
+::: aic._bindings.process_interleaved
+    options:
+      show_root_heading: true
+      heading_level: 3
+      show_object_full_path: false
+
+## Parameters
+
+::: aic._bindings.set_parameter
+    options:
+      show_root_heading: true
+      heading_level: 3
+      show_object_full_path: false
+
+::: aic._bindings.get_parameter
+    options:
+      show_root_heading: true
+      heading_level: 3
+      show_object_full_path: false
+
+## Information helpers
+
+::: aic._bindings.get_processing_latency
+    options:
+      show_root_heading: true
+      heading_level: 3
+      show_object_full_path: false
+
+::: aic._bindings.get_output_delay
+    options:
+      show_root_heading: true
+      heading_level: 3
+      show_object_full_path: false
+
+::: aic._bindings.get_optimal_sample_rate
+    options:
+      show_root_heading: true
+      heading_level: 3
+      show_object_full_path: false
+
+::: aic._bindings.get_optimal_num_frames
+    options:
+      show_root_heading: true
+      heading_level: 3
+      show_object_full_path: false
+
+::: aic._bindings.get_library_version
+    options:
+      show_root_heading: true
+      heading_level: 3
+      show_object_full_path: false
+
+## Enums
+
+::: aic._bindings.AICErrorCode
+    options:
+      show_root_heading: true
+      heading_level: 3
+      show_object_full_path: false
+
+::: aic._bindings.AICModelType
+    options:
+      show_root_heading: true
+      heading_level: 3
+      show_object_full_path: false
+
+::: aic._bindings.AICParameter
+    options:
+      show_root_heading: true
+      heading_level: 3
+      show_object_full_path: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - API Reference: api.md
+  - Low-level C Bindings: low-level-bindings.md
   - Examples: examples.md
 
 extra:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aic-sdk"
-version = "0.6.1"
+version = "1.0.0"
 description = "Python bindings for the ai-coustics speech-enhancement SDK"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -24,3 +24,29 @@ Homepage = "https://github.com/ai-coustics/aic-sdk-py"
 Documentation = "https://ai-coustics.github.io/aic-sdk-py/"
 Source = "https://github.com/ai-coustics/aic-sdk-py"
 Issues = "https://github.com/ai-coustics/aic-sdk-py/issues"
+
+[tool.aic-sdk]
+sdk-version = "0.6.2"
+
+[tool.ruff]
+line-length = 120
+src = ["aic", "tests"]
+target-version = "py313"
+lint.ignore = [
+    "ASYNC230",
+    "COM812",
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "DTZ005",
+    "EM101",
+    "EM102",
+    "PLR0913",
+    "TRY002",
+    "TRY003",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,5 @@ mkdocs>=1.5
 mkdocs-material>=9.0
 mkdocstrings-python>=1.7
 
+pre-commit>=3.7
+ruff>=0.12

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,5 +7,3 @@ sys.path.insert(0, str(REPO_ROOT))
 
 # If a different 'aic' is already imported, drop it so tests use the local one
 sys.modules.pop("aic", None)
-
-

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1,6 +1,3 @@
-import ctypes as ct
-import types
-
 import pytest
 
 
@@ -74,13 +71,6 @@ def test_raise_on_error():
         _raise(AICErrorCode.LICENSE_INVALID)
 
 
-def test_get_library_version(monkeypatch):
-    from aic._bindings import get_library_version
-
-    _install_fake_lib(monkeypatch)
-    assert get_library_version() == "9.9.9"
-
-
 def test_successful_wrappers(monkeypatch):
     import aic._bindings as b
 
@@ -114,5 +104,3 @@ def test_successful_wrappers(monkeypatch):
     assert fake.aic_get_output_delay.calls
     assert fake.aic_get_optimal_sample_rate.calls
     assert fake.aic_get_optimal_num_frames.calls
-
-

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,4 +1,3 @@
-import importlib
 from pathlib import Path
 
 import pytest
@@ -60,5 +59,3 @@ def test_loader_unsupported_os(monkeypatch):
     monkeypatch.setattr(loader.platform, "system", lambda: "Plan9")
     with pytest.raises(RuntimeError):
         loader._path()
-
-


### PR DESCRIPTION
# Summary
This PR refactors the high-level API and CI to simplify usage, improve defaults, and decouple Python package versioning from SDK binary versioning.

## Highlights
- **Remove `initialize()`:** All model initialization logic is now in `Model.__init__`.
- **New constructor API:**
  - `sample_rate`: required
  - `channels`: optional, defaults to `1`
  - `frames`: optional, defaults to `None` → chooses `optimal_num_frames()` automatically
- **Auto-selection:** Only performed when `model_type` is `QUAIL_L` or `QUAIL_S` (family aliases).  
  For all other explicit types (e.g., `QUAIL_L48`, `QUAIL_S16`, `QUAIL_XS`), the exact type is used as-is.
- **Default behavior:** Noise gate is enabled (`1.0`) on initialization.
- **Docs & examples:** Updated to the constructor-only API (no `initialize()` calls).

### Tests
- Updated unit and integration tests to use the new constructor.
- Added an integration test asserting  
  `Model(QUAIL_L, sample_rate=8000, ...)` reports `optimal_sample_rate() == 8000`.

### CI workflow
- `.github/workflows/build-and-publish.yml` now reads SDK binary version from `pyproject.toml → [tool.aic-sdk].sdk-version`.
- Python package version still comes from the git tag; SDK assets are downloaded using the `sdk-version`.  
  This decouples Python release versioning from native SDK versioning.

## Breaking Changes
- **Removed:** `Model.initialize(...)`
- **Constructor:**
  - `sample_rate` is now required.
  - Users must pass `channels` only when different from default (`1`).
  - `frames` can be omitted to use optimal frames automatically.

## Migration Guide
**Before:**
```python
Model(...); 
model.initialize(sample_rate=48000, channels=1, frames=480)
```
**After:**
```python
Model(..., sample_rate=48000, channels=1, frames=480)
# or simply
Model(..., sample_rate=48000)
# if defaults are sufficient
```

## Additional Notes
- Minor type hint and style improvements in aic/__init__.py.
- Ensured explicit model types are respected without normalization; auto-selection is limited to QUAIL_L/QUAIL_S.