### PR TITLE
Release the GIL when running the sync Rust process call

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -466,10 +466,13 @@ impl Processor {
     ) -> PyResult<Bound<'py, numpy::PyArray2<f32>>> {
         let mut array = buffer.as_array().as_standard_layout().into_owned();
 
-        // Process using sequential format (channel-contiguous)
-        self.processor
-            .process_sequential(array.as_slice_mut().expect("Array is in standard layout"))
-            .map_err(to_py_err)?;
+        // We release the GIL here so any other Python threads get a chance to run
+        py.detach(|| {
+            // Process using sequential format (channel-contiguous)
+            self.processor
+                .process_sequential(array.as_slice_mut().expect("Array is in standard layout"))
+                .map_err(to_py_err)
+        })?;
 
         // Convert back to numpy array
         use numpy::ToPyArray;


### PR DESCRIPTION
Ran into this while investigating the high-latency spikes issue.

This change allows other Python threads to run while the Processor call is running. See the [docs](https://docs.rs/pyo3/latest/pyo3/marker/struct.Python.html#method.detach) for the detach function for reference.

I don't think this fixes the latency issue, especially because this seems to only matter for the sync processor. This change does not affect the async processor, and the latency issue has been observed in async as well.