### PR TITLE
Move async processing to rayon thread pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,7 @@ dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
  "pyo3-stub-gen",
+ "rayon",
  "tokio",
 ]
 
@@ -256,6 +257,31 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -1148,6 +1174,26 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ numpy = "0.27"
 pyo3 = { version = "0.27", features = ["generate-import-lib", "multiple-pymethods"] }
 pyo3-async-runtimes = { version = "0.27", features = ["tokio-runtime"] }
 pyo3-stub-gen = { version = "0.20", default-features = false, features = ["infer_signature"] }
-tokio = { version = "1.49", features = ["rt", "rt-multi-thread"] }
+rayon = "1"
+tokio = { version = "1.49", features = ["rt", "rt-multi-thread", "sync"] }
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -197,6 +197,11 @@ if vad_ctx.is_speech_detected():
 - **`Processor` (sync)**: Simple scripts, command-line tools, batch processing
 - **`ProcessorAsync` (async)**: Web servers, real-time applications, concurrent stream processing
 
+`ProcessorAsync` runs CPU-bound work on a dedicated [Rayon](https://docs.rs/rayon)
+thread pool. By default the pool is sized to the number of logical cores reported
+by the OS. Set the `AIC_NUM_THREADS` environment variable to override the worker
+count — for example `AIC_NUM_THREADS=2` caps concurrent processing at two threads.
+
 ### Error Handling
 
 The SDK provides specific exception types for different error conditions. All exceptions include a `message` attribute with details about the error.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ if vad_ctx.is_speech_detected():
 `ProcessorAsync` runs CPU-bound work on a dedicated [Rayon](https://docs.rs/rayon)
 thread pool. By default the pool is sized to the number of logical cores reported
 by the OS. Set the `AIC_NUM_THREADS` environment variable to override the worker
-count — for example `AIC_NUM_THREADS=2` caps concurrent processing at two threads.
+count, for example `AIC_NUM_THREADS=2` caps concurrent processing at two threads.
 
 ### Error Handling
 

--- a/aic_sdk.pyi
+++ b/aic_sdk.pyi
@@ -518,10 +518,13 @@ class Processor:
 @typing.final
 class ProcessorAsync:
     r"""
-    Async wrapper for Processor that offloads processing to a thread pool.
+    Async wrapper for Processor that offloads work to background threads.
 
     This class provides the same functionality as Processor but with async methods
-    that don't block the event loop.
+    that don't block the event loop. `process_async` runs on a dedicated Rayon pool
+    sized by the `AIC_NUM_THREADS` environment variable, defaulting to the number
+    of logical cores available on the system. `initialize_async` runs on Tokio's
+    blocking pool since it is one-shot and may allocate.
 
     Example:
         >>> model = Model.from_file("/path/to/model.aicmodel")

--- a/aic_sdk.pyi
+++ b/aic_sdk.pyi
@@ -521,10 +521,8 @@ class ProcessorAsync:
     Async wrapper for Processor that offloads work to background threads.
 
     This class provides the same functionality as Processor but with async methods
-    that don't block the event loop. `process_async` runs on a dedicated Rayon pool
-    sized by the `AIC_NUM_THREADS` environment variable, defaulting to the number
-    of logical cores available on the system. `initialize_async` runs on Tokio's
-    blocking pool since it is one-shot and may allocate.
+    that don't block the event loop. Processing thread count is controlled by the
+    `AIC_NUM_THREADS` environment variable.
 
     Example:
         >>> model = Model.from_file("/path/to/model.aicmodel")

--- a/src/processor_async.rs
+++ b/src/processor_async.rs
@@ -7,13 +7,37 @@ use crate::{
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
-use std::sync::{Arc, Mutex};
-use tokio::task;
+use std::sync::{Arc, Mutex, OnceLock};
 
-/// Async wrapper for Processor that offloads processing to a thread pool.
+static RAYON_POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
+
+fn pool() -> &'static rayon::ThreadPool {
+    RAYON_POOL.get_or_init(|| {
+        let num_threads = std::env::var("AIC_NUM_THREADS")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or_else(|| {
+                std::thread::available_parallelism()
+                    .map(|n| n.get())
+                    .unwrap_or(1)
+            });
+
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(num_threads)
+            .thread_name(|i| format!("aic-rayon-{i}"))
+            .build()
+            .expect("failed to build aic rayon pool")
+    })
+}
+
+/// Async wrapper for Processor that offloads work to background threads.
 ///
 /// This class provides the same functionality as Processor but with async methods
-/// that don't block the event loop.
+/// that don't block the event loop. `process_async` runs on a dedicated Rayon pool
+/// sized by the `AIC_NUM_THREADS` environment variable, defaulting to the number
+/// of logical cores available on the system. `initialize_async` runs on Tokio's
+/// blocking pool since it is one-shot and may allocate.
 ///
 /// Example:
 ///     >>> model = Model.from_file("/path/to/model.aicmodel")
@@ -98,7 +122,7 @@ impl ProcessorAsync {
         let model = Arc::clone(&self.inner);
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            task::spawn_blocking(move || {
+            tokio::task::spawn_blocking(move || {
                 let mut model = model.lock().unwrap();
                 model.initialize(&config)
             })
@@ -149,17 +173,24 @@ impl ProcessorAsync {
         let array = buffer.as_array().as_standard_layout().into_owned();
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let processed = task::spawn_blocking(move || {
-                let mut processor = processor.lock().unwrap();
-                let mut array = array;
-                processor
-                    .processor
-                    .process_sequential(array.as_slice_mut().expect("Array is in standard layout"))
-                    .map_err(to_py_err)?;
-                Ok::<numpy::ndarray::Array2<f32>, PyErr>(array)
-            })
-            .await
-            .map_err(|e| PyRuntimeError::new_err(format!("Task error: {}", e)))??;
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            pool().spawn(move || {
+                let result = (|| {
+                    let mut processor = processor.lock().unwrap();
+                    let mut array = array;
+                    processor
+                        .processor
+                        .process_sequential(
+                            array.as_slice_mut().expect("Array is in standard layout"),
+                        )
+                        .map_err(to_py_err)?;
+                    Ok::<numpy::ndarray::Array2<f32>, PyErr>(array)
+                })();
+                let _ = tx.send(result);
+            });
+            let processed = rx
+                .await
+                .map_err(|_| PyRuntimeError::new_err("rayon worker dropped"))??;
 
             let result_obj = Python::attach(|py| {
                 use numpy::ToPyArray;

--- a/src/processor_async.rs
+++ b/src/processor_async.rs
@@ -7,7 +7,8 @@ use crate::{
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pymethods};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, OnceLock};
+use tokio::sync::Mutex;
 
 static RAYON_POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
 
@@ -117,15 +118,13 @@ impl ProcessorAsync {
         config: ProcessorConfig,
         py: Python<'py>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let model = Arc::clone(&self.inner);
+        let inner = Arc::clone(&self.inner);
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            tokio::task::spawn_blocking(move || {
-                let mut model = model.lock().unwrap();
-                model.initialize(&config)
-            })
-            .await
-            .map_err(|e| PyRuntimeError::new_err(format!("Task error: {}", e)))?
+            let mut model = inner.lock_owned().await;
+            tokio::task::spawn_blocking(move || model.initialize(&config))
+                .await
+                .map_err(|e| PyRuntimeError::new_err(format!("Task error: {}", e)))?
         })
     }
 
@@ -139,7 +138,7 @@ impl ProcessorAsync {
     /// Example:
     ///     >>> processor_context = processor.get_processor_context()
     pub fn get_processor_context(&self) -> ProcessorContext {
-        let processor = self.inner.lock().unwrap();
+        let processor = self.inner.blocking_lock();
         processor.get_processor_context()
     }
 
@@ -152,7 +151,7 @@ impl ProcessorAsync {
     /// Example:
     ///     >>> vad = processor.get_vad_context()
     pub fn get_vad_context(&self) -> VadContext {
-        let processor = self.inner.lock().unwrap();
+        let processor = self.inner.blocking_lock();
         processor.get_vad_context()
     }
 }
@@ -166,14 +165,14 @@ impl ProcessorAsync {
         buffer: numpy::PyReadonlyArray2<'py, f32>,
         py: Python<'py>,
     ) -> PyResult<Bound<'py, pyo3::types::PyAny>> {
-        let processor = Arc::clone(&self.inner);
+        let inner = Arc::clone(&self.inner);
 
         let mut array = buffer.as_array().as_standard_layout().into_owned();
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mut processor = inner.lock_owned().await;
             let (tx, rx) = tokio::sync::oneshot::channel();
             pool().spawn(move || {
-                let mut processor = processor.lock().unwrap();
                 let result = processor
                     .processor
                     .process_sequential(array.as_slice_mut().expect("Array is in standard layout"))

--- a/src/processor_async.rs
+++ b/src/processor_async.rs
@@ -25,19 +25,17 @@ fn pool() -> &'static rayon::ThreadPool {
 
         rayon::ThreadPoolBuilder::new()
             .num_threads(num_threads)
-            .thread_name(|i| format!("aic-rayon-{i}"))
+            .thread_name(|i| format!("aic-processing-thread-{i}"))
             .build()
-            .expect("failed to build aic rayon pool")
+            .expect("failed to build aic thread-pool")
     })
 }
 
 /// Async wrapper for Processor that offloads work to background threads.
 ///
 /// This class provides the same functionality as Processor but with async methods
-/// that don't block the event loop. `process_async` runs on a dedicated Rayon pool
-/// sized by the `AIC_NUM_THREADS` environment variable, defaulting to the number
-/// of logical cores available on the system. `initialize_async` runs on Tokio's
-/// blocking pool since it is one-shot and may allocate.
+/// that don't block the event loop. Processing thread count is controlled by the
+/// `AIC_NUM_THREADS` environment variable.
 ///
 /// Example:
 ///     >>> model = Model.from_file("/path/to/model.aicmodel")
@@ -190,7 +188,7 @@ impl ProcessorAsync {
             });
             let processed = rx
                 .await
-                .map_err(|_| PyRuntimeError::new_err("rayon worker dropped"))??;
+                .map_err(|_| PyRuntimeError::new_err("Rayon worker dropped"))??;
 
             let result_obj = Python::attach(|py| {
                 use numpy::ToPyArray;

--- a/src/processor_async.rs
+++ b/src/processor_async.rs
@@ -168,22 +168,17 @@ impl ProcessorAsync {
     ) -> PyResult<Bound<'py, pyo3::types::PyAny>> {
         let processor = Arc::clone(&self.inner);
 
-        let array = buffer.as_array().as_standard_layout().into_owned();
+        let mut array = buffer.as_array().as_standard_layout().into_owned();
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let (tx, rx) = tokio::sync::oneshot::channel();
             pool().spawn(move || {
-                let result = (|| {
-                    let mut processor = processor.lock().unwrap();
-                    let mut array = array;
-                    processor
-                        .processor
-                        .process_sequential(
-                            array.as_slice_mut().expect("Array is in standard layout"),
-                        )
-                        .map_err(to_py_err)?;
-                    Ok::<numpy::ndarray::Array2<f32>, PyErr>(array)
-                })();
+                let mut processor = processor.lock().unwrap();
+                let result = processor
+                    .processor
+                    .process_sequential(array.as_slice_mut().expect("Array is in standard layout"))
+                    .map_err(to_py_err)
+                    .map(|_| array);
                 let _ = tx.send(result);
             });
             let processed = rx

--- a/taplo.toml
+++ b/taplo.toml
@@ -3,6 +3,9 @@ column_width = 100
 reorder_arrays = true
 reorder_keys = true
 
+[schema]
+enabled = false
+
 [[rule]]
 formatting = { reorder_keys = true }
 keys = ["package.*"]


### PR DESCRIPTION
As stated in this blog-post CPU bound tasks should be done on the rayon threadpool instead of the tokio blocking pool. (according to https://ryhl.io/blog/async-what-is-blocking/)

The number of threads that are used are by default the number of logical CPU cores and can be configured with the env var `AIC_NUM_THREADS` at runtime.

The initialize function will continue to run on the tokio threadpool to not steal any work from the audio threads.

This is still tested by Corvin in benchmarks to see if this is improving the number of parallel sessions or not.