### PR TITLE
Release 2.2.1

### DIFF
--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@beta
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: astral-sh/setup-uv@v7
       - run: make stubs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is inspired by Keep a Changelog, and this project adheres to semantic versioning for the Python package. The native SDK binaries are versioned independently.
 
+## 2.2.1 - 2026-05-06
+
+Update to core library version 0.17.1.
+
+## Improvements
+
+- Increased maximum VAD speech hold duration from 100x to 300x the model's window size.
+
+## Bug Fixes
+
+- Removed zero-padding when the host frame size does not match the model frame size, which caused unexpected behavior for some models.
+
 ## 2.2.0 - 2026-04-23
 
 Update to core library version 0.17.0.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aic-sdk"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce1ae1f87880c1662edc088fe6aa81f650bcdd4ecd0b646fe0754bfc46a0000"
+checksum = "3920075355fe29fb65620d3ebb1c2c720af9c84864d6f49556a825bd2603cf71"
 dependencies = [
  "aic-sdk-sys",
  "serde",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "aic-sdk-py"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "aic-sdk",
  "numpy",
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "aic-sdk-sys"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9435d24d2ac8550e140723aaa641234f18cbed2fa57cebdcaf94a9f9877304"
+checksum = "1f7b1b236aa7c2211633b487303e43411c5f9e72db3ecc272641b57c232db885"
 dependencies = [
  "bindgen",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["stub-gen"]
 edition = "2024"
 name = "aic-sdk-py"
 rust-version = "1.88"
-version = "2.2.0"
+version = "2.2.1"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -15,7 +15,7 @@ name = "aic_sdk"
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-aic-sdk = { version = "0.17.0", features = ["download-lib", "download-model"] }
+aic-sdk = { version = "0.17.1", features = ["download-lib", "download-model"] }
 numpy = "0.27"
 pyo3 = { version = "0.27", features = ["generate-import-lib", "multiple-pymethods"] }
 pyo3-async-runtimes = { version = "0.27", features = ["tokio-runtime"] }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -51,5 +51,6 @@ uv run --env-file .env pytest
 1. Create a new branch
 2. Update version in `pyproject.toml` and run `uv lock` to update `uv.lock` file.
 3. Update version also in `Cargo.toml` and run `cargo build` to update the `Cargo.lock` file.
-4. Create a PR and merge it into `main`
-5. Create a GitHub release with a new tag of the version number `x.x.x` - the workflow will automatically build and publish to PyPI
+4. Create new stubs: `make stubs`.
+5. Create a PR and merge it into `main`
+6. Create a GitHub release with a new tag of the version number `x.x.x` - the workflow will automatically build and publish to PyPI

--- a/aic_sdk.pyi
+++ b/aic_sdk.pyi
@@ -999,7 +999,7 @@ class VadParameter(enum.Enum):
         length of 10 ms, the VAD will round up/down to the closest multiple of 10 ms.
         Because of this, this parameter may return a different value than the one it was last set to.
 
-    Range: 0.0 to 100x model window length (value in seconds)
+    Range: 0.0 to 300x model window length (value in seconds)
 
     Default: 0.03 (30 ms)
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license = { file = "LICENSE" }
 name = "aic-sdk"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "2.2.0"
+version = "2.2.1"
 
 [dependency-groups]
 dev = ["pytest-asyncio>=1.3.0", "pytest>=9.0.2"]

--- a/src/vad.rs
+++ b/src/vad.rs
@@ -27,7 +27,7 @@ pub enum VadParameter {
     ///     length of 10 ms, the VAD will round up/down to the closest multiple of 10 ms.
     ///     Because of this, this parameter may return a different value than the one it was last set to.
     ///
-    /// Range: 0.0 to 100x model window length (value in seconds)
+    /// Range: 0.0 to 300x model window length (value in seconds)
     ///
     /// Default: 0.03 (30 ms)
     SpeechHoldDuration,

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "aic-sdk"
-version = "2.2.0"
+version = "2.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Improvements

- Increased maximum VAD speech hold duration from 100x to 300x the model's window size.

## Bug Fixes

- Removed zero-padding when the host frame size does not match the model frame size, which caused unexpected behavior for some models.