### PR TITLE
CI: parallelize building (and testing) wheels for different Python versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,20 +37,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        interpreter: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: ubuntu-latest
             targets: x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu
-            interpreters: '3.10 3.11 3.12 3.13 3.14'
             test-arch: x86_64
             use-zig: true
           - os: macos-latest
             targets: x86_64-apple-darwin aarch64-apple-darwin
-            interpreters: '3.10 3.11 3.12 3.13 3.14'
             test-arch: arm64
             use-zig: false
           - os: windows-latest
             targets: x86_64-pc-windows-msvc aarch64-pc-windows-msvc
-            interpreters: '3.10 3.11 3.12 3.13 3.14'
             test-arch: amd64
             use-zig: false
 
@@ -67,9 +66,9 @@ jobs:
         with:
           targets: ${{ matrix.targets }}
 
-      - name: Install Python interpreters
+      - name: Install Python
         shell: bash
-        run: uv python install ${{ matrix.interpreters }}
+        run: uv python install ${{ matrix.interpreter }}
 
       - name: Build wheels
         shell: bash
@@ -77,9 +76,9 @@ jobs:
           for target in ${{ matrix.targets }}; do
             echo "Building for $target"
             if [ "${{ matrix.use-zig }}" = "true" ]; then
-              uvx --from maturin[zig] maturin build --zig --release --target $target --out dist --interpreter ${{ matrix.interpreters }}
+              uvx --from maturin[zig] maturin build --zig --release --target $target --out dist --interpreter ${{ matrix.interpreter }}
             else
-              uvx maturin build --release --target $target --out dist --interpreter ${{ matrix.interpreters }}
+              uvx maturin build --release --target $target --out dist --interpreter ${{ matrix.interpreter }}
             fi
           done
 
@@ -88,17 +87,16 @@ jobs:
         env:
           AIC_SDK_LICENSE: ${{ secrets.AIC_SDK_LICENSE }}
         run: |
-          for version in ${{ matrix.interpreters }}; do
-            echo "Testing Python $version"
-            uv venv --python $version .venv-$version
-            VIRTUAL_ENV=.venv-$version uv pip install dist/*cp${version//.}*${{ matrix.test-arch }}*.whl
+          version=${{ matrix.interpreter }}
+          echo "Testing Python $version"
+          uv venv --python $version .venv-$version
+          VIRTUAL_ENV=.venv-$version uv pip install dist/*cp${version//.}*${{ matrix.test-arch }}*.whl
 
-            if [ -x ".venv-$version/bin/python" ]; then
-              python=".venv-$version/bin/python"
-            else
-              python=".venv-$version/Scripts/python.exe"
-            fi
+          if [ -x ".venv-$version/bin/python" ]; then
+            python=".venv-$version/bin/python"
+          else
+            python=".venv-$version/Scripts/python.exe"
+          fi
 
-            "$python" examples/basic.py
-            "$python" examples/basic_async.py
-          done
+          "$python" examples/basic.py
+          "$python" examples/basic_async.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,9 @@ jobs:
         run: uv run pytest
 
   build:
-    needs: test
     name: Build and test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         interpreter: ["3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Run Integration Tests
+name: Build and test wheels
 
 on:
   push:
@@ -7,31 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    env:
-      AIC_SDK_LICENSE: ${{ secrets.AIC_SDK_LICENSE }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          enable-cache: true
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install dependencies and build
-        run: |
-          uv sync --group dev
-          uvx maturin develop
-
-      - name: Run tests
-        run: uv run pytest
-
   build:
-    name: Build and test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      AIC_SDK_LICENSE: ${{ secrets.AIC_SDK_LICENSE }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies and build
+        run: |
+          uv sync --group dev
+          uvx maturin develop
+
+      - name: Run tests
+        run: uv run pytest


### PR DESCRIPTION
~I don't know if this will work ... but I have to try it here for the GitHub actions to run ...~

~No review necessary for now.~

This does 2 things:
* move the `pytest` call (only executed on Ubuntu) to a separate workflow
  * before, this was only run on branches based on `main`, now it runs on all branches
  * the other tests don't wait for this anymore
* parallelize the Python version tests
  * I restored the default "fail fast" setting: if one test fails, the other are interrupted
  * these tests are still only run on branches based on `main`

This reduces the CI job duration from about 16.5 minutes to about 6 minutes.

About 3 minutes are saved by not waiting for the `pytest` run, the rest comes from parallelizing.

The limiting factor now (as before) are the Windows tests, which take up to 6 minutes each.