### PR TITLE
Release 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is inspired by Keep a Changelog, and this project adheres to semantic versioning for the Python package. The native SDK binaries are versioned independently.
 
+## 2.5.0 - 2026-06-23
+
+Update to core library version 0.21.0.
+
+### New Features
+
+- Added `VadContext.raw_vad_probability()`, which returns the VAD model's raw prediction
+  without the SDK's post-processing (speech hold duration, sensitivity thresholding, etc.).
+  This value can be used to build custom abstractions on top of the raw VAD output. When using
+  an energy-based VAD, the raw prediction is `1.0` or `0.0` depending on
+  `VadContext.is_speech_detected()`.
+
+### Improvements
+
+- Reduced the necessary output delay of the `Processor` when using `allow_variable_frames=True`.
+
 ## 2.4.0 - 2026-06-11
 
 Update to core library version 0.20.0.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aic-model-downloader"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b08bf0672f1d52bfbf19cbd368b3498d0dd1850330b252431cb5af02992d60c"
+checksum = "060b7a783a6e1e616fe4940337b9a5618be7d4010be475792d4bd0e5e76aefab"
 dependencies = [
  "serde",
  "serde_json",
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "aic-sdk"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5acc8d1c88477b5ce806a1615d7efb7d6628956ff8a14d549a6699835e589393"
+checksum = "c1ebca813f22d9b0f1260118774f547dbbd5069b4feeeccf7d39b779c5f97fe2"
 dependencies = [
  "aic-model-downloader",
  "aic-sdk-sys",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "aic-sdk-py"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "aic-sdk",
  "numpy",
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "aic-sdk-sys"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7aa85d335f6916a9eac920a7d2bcfb28a9e1bb80299574d7ed717f280d0c59"
+checksum = "7b248245f7731125a17855ba59b9402041ccd49f318fbc973be6232cd0fbdc2a"
 dependencies = [
  "bindgen",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["stub-gen"]
 edition = "2024"
 name = "aic-sdk-py"
 rust-version = "1.88"
-version = "2.4.0"
+version = "2.5.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -15,7 +15,7 @@ name = "aic_sdk"
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-aic-sdk = { version = "0.20.0", features = ["async", "download-lib", "download-model"] }
+aic-sdk = { version = "0.21.0", features = ["async", "download-lib", "download-model"] }
 numpy = "0.27"
 pyo3 = { version = "0.27", features = ["generate-import-lib", "multiple-pymethods"] }
 pyo3-async-runtimes = { version = "0.27", features = ["tokio-runtime"] }

--- a/aic_sdk.pyi
+++ b/aic_sdk.pyi
@@ -1266,6 +1266,31 @@ class VadContext:
         Returns:
             True if speech is detected, False otherwise.
         """
+    def raw_vad_probability(self) -> builtins.float:
+        r"""
+        Returns the raw prediction of the VAD, without any processing.
+
+        In contrast to the output of is_speech_detected(), the output of this function
+        is the model's direct prediction without going through the SDK's VAD
+        post-processing (i.e. speech hold duration, sensitivity thresholding, etc.).
+
+        This value may be used to build other abstractions on top of this data.
+
+        Note:
+            This value is only useful when using a VAD model. When using an energy-based VAD,
+            the raw prediction is set to 1.0 or 0.0 depending on whether is_speech_detected()
+            is true or false.
+
+        Important:
+            - The latency of the VAD prediction is equal to the backing model's processing
+              latency, reported by ProcessorContext.get_output_delay(). The prediction lags its
+              input by that many samples, so align speech decisions to the input timeline using
+              that delay.
+            - If the backing model stops being processed, the VAD will not update its prediction.
+
+        Returns:
+            The raw VAD probability.
+        """
     def set_parameter(self, parameter: VadParameter, value: builtins.float) -> None:
         r"""
         Modifies a VAD parameter.

--- a/aic_sdk.pyi
+++ b/aic_sdk.pyi
@@ -1244,7 +1244,10 @@ class VadContext:
     that created the VAD.
 
     Important:
-        - The latency of the VAD prediction is equal to the backing model's processing latency.
+        - The latency of the VAD prediction is equal to the backing model's processing
+          latency, reported by ProcessorContext.get_output_delay(). The prediction lags its
+          input by that many samples, so align speech decisions to the input timeline using
+          that delay.
         - If the backing model stops being processed, the VAD will not update its speech detection prediction.
 
     Created via Processor.get_vad_context().
@@ -1260,7 +1263,10 @@ class VadContext:
         Returns the VAD's prediction.
 
         Important:
-            - The latency of the VAD prediction is equal to the backing model's processing latency.
+            - The latency of the VAD prediction is equal to the backing model's processing
+              latency, reported by ProcessorContext.get_output_delay(). The prediction lags its
+              input by that many samples, so align speech decisions to the input timeline using
+              that delay.
             - If the backing model stops being processed, the VAD will not update its speech detection prediction.
 
         Returns:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license = { file = "LICENSE" }
 name = "aic-sdk"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "2.4.0"
+version = "2.5.0"
 
 [dependency-groups]
 dev = ["pytest-asyncio>=1.3.0", "pytest>=9.0.2"]

--- a/src/vad.rs
+++ b/src/vad.rs
@@ -75,7 +75,10 @@ impl From<VadParameter> for aic_sdk::VadParameter {
 /// that created the VAD.
 ///
 /// Important:
-///     - The latency of the VAD prediction is equal to the backing model's processing latency.
+///     - The latency of the VAD prediction is equal to the backing model's processing
+///       latency, reported by ProcessorContext.get_output_delay(). The prediction lags its
+///       input by that many samples, so align speech decisions to the input timeline using
+///       that delay.
 ///     - If the backing model stops being processed, the VAD will not update its speech detection prediction.
 ///
 /// Created via Processor.get_vad_context().
@@ -97,7 +100,10 @@ impl VadContext {
     /// Returns the VAD's prediction.
     ///
     /// Important:
-    ///     - The latency of the VAD prediction is equal to the backing model's processing latency.
+    ///     - The latency of the VAD prediction is equal to the backing model's processing
+    ///       latency, reported by ProcessorContext.get_output_delay(). The prediction lags its
+    ///       input by that many samples, so align speech decisions to the input timeline using
+    ///       that delay.
     ///     - If the backing model stops being processed, the VAD will not update its speech detection prediction.
     ///
     /// Returns:

--- a/src/vad.rs
+++ b/src/vad.rs
@@ -106,6 +106,32 @@ impl VadContext {
         self.inner.is_speech_detected()
     }
 
+    /// Returns the raw prediction of the VAD, without any processing.
+    ///
+    /// In contrast to the output of is_speech_detected(), the output of this function
+    /// is the model's direct prediction without going through the SDK's VAD
+    /// post-processing (i.e. speech hold duration, sensitivity thresholding, etc.).
+    ///
+    /// This value may be used to build other abstractions on top of this data.
+    ///
+    /// Note:
+    ///     This value is only useful when using a VAD model. When using an energy-based VAD,
+    ///     the raw prediction is set to 1.0 or 0.0 depending on whether is_speech_detected()
+    ///     is true or false.
+    ///
+    /// Important:
+    ///     - The latency of the VAD prediction is equal to the backing model's processing
+    ///       latency, reported by ProcessorContext.get_output_delay(). The prediction lags its
+    ///       input by that many samples, so align speech decisions to the input timeline using
+    ///       that delay.
+    ///     - If the backing model stops being processed, the VAD will not update its prediction.
+    ///
+    /// Returns:
+    ///     The raw VAD probability.
+    fn raw_vad_probability(&self) -> f32 {
+        self.inner.raw_vad_probability()
+    }
+
     /// Modifies a VAD parameter.
     ///
     /// Args:

--- a/tests/test_vad_context.py
+++ b/tests/test_vad_context.py
@@ -83,6 +83,18 @@ def test_vad_context_silence_not_detected_as_speech(model, license_key):
     assert vad.is_speech_detected() is False
 
 
+def test_vad_context_raw_vad_probability_returns_float(model, license_key):
+    processor = create_processor_or_skip(model, license_key)
+    config = aic.ProcessorConfig(48000, 1, 480, False)
+    processor.initialize(config)
+    vad = processor.get_vad_context()
+    audio = np.zeros((1, 480), dtype=np.float32)
+    processor.process(audio)
+    result = vad.raw_vad_probability()
+    assert isinstance(result, float)
+    assert 0.0 <= result <= 1.0
+
+
 def test_vad_context_updates_after_each_process_call(model, license_key):
     processor = create_processor_or_skip(model, license_key)
     config = aic.ProcessorConfig(48000, 1, 480, False)

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "aic-sdk"
-version = "2.4.0"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
This is modeled after the Rust bindings in https://github.com/ai-coustics/aic-sdk-rs/pull/71.

### New Features

- Added `VadContext.raw_vad_probability()`, which returns the VAD model's raw prediction
  without the SDK's post-processing (speech hold duration, sensitivity thresholding, etc.).
  This value can be used to build custom abstractions on top of the raw VAD output. When using
  an energy-based VAD, the raw prediction is `1.0` or `0.0` depending on
  `VadContext.is_speech_detected()`.

### Improvements

- Reduced the necessary output delay of the `Processor` when using `allow_variable_frames=True`.
