### PR TITLE
Remove redundant array copy in FileAnalyzer::analyze()

### DIFF
--- a/src/file_analyzer.rs
+++ b/src/file_analyzer.rs
@@ -105,11 +105,12 @@ impl FileAnalyzer {
         step_samples: Option<usize>,
         py: Python<'py>,
     ) -> PyResult<Vec<AnalysisResult>> {
-        let owned = audio.as_array().as_standard_layout().into_owned();
-        let audio_vec = owned
-            .as_slice()
-            .expect("Array is in standard layout")
-            .to_vec();
+        let audio_vec = audio
+            .as_array()
+            .as_standard_layout()
+            .into_owned()
+            .into_raw_vec_and_offset()
+            .0;
 
         let inner = &mut self.inner;
 

--- a/src/file_analyzer.rs
+++ b/src/file_analyzer.rs
@@ -105,19 +105,20 @@ impl FileAnalyzer {
         step_samples: Option<usize>,
         py: Python<'py>,
     ) -> PyResult<Vec<AnalysisResult>> {
-        let audio_vec = audio
-            .as_array()
-            .as_standard_layout()
-            .into_owned()
-            .into_raw_vec_and_offset()
-            .0;
+        let audio = audio.as_array().as_standard_layout().into_owned();
 
         let inner = &mut self.inner;
 
         // The heavy native work (initialize + buffer + analyze) runs without the GIL so other
         // Python threads can make progress.
         let results = py
-            .detach(move || inner.analyze(&audio_vec, sample_rate, step_samples))
+            .detach(move || {
+                inner.analyze(
+                    audio.as_slice().expect("Array is in standard layout"),
+                    sample_rate,
+                    step_samples,
+                )
+            })
             .map_err(to_py_err)?;
 
         Ok(results.into_iter().map(AnalysisResult::from).collect())

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,4 +1,3 @@
-use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::{gen_stub_pyclass, gen_stub_pyclass_enum, gen_stub_pymethods};
 
@@ -505,11 +504,8 @@ impl Processor {
                 .map_err(to_py_err)
         })?;
 
-        // Convert back to numpy array
-        use numpy::ToPyArray;
-        array
-            .to_pyarray(py)
-            .cast_into_exact::<numpy::PyArray2<f32>>()
-            .map_err(|_| PyRuntimeError::new_err("Failed to convert result to PyArray2"))
+        // Move the owned, already-processed array into a numpy array without copying.
+        use numpy::IntoPyArray;
+        Ok(array.into_pyarray(py))
     }
 }

--- a/src/processor_async.rs
+++ b/src/processor_async.rs
@@ -166,17 +166,19 @@ impl ProcessorAsync {
         let array = buffer.as_array().as_standard_layout().into_owned();
         let num_channels = array.shape()[0];
         let num_frames = array.shape()[1];
-        let vec = array.as_slice().expect("standard layout").to_vec();
+        // process_sequential consumes an owned Vec for the 'static async task, so take the
+        // owned array's backing buffer directly instead of copying it again.
+        let vec = array.into_raw_vec_and_offset().0;
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let processed = inner.process_sequential(vec).await.map_err(to_py_err)?;
 
             let result_obj = Python::attach(|py| {
-                use numpy::ToPyArray;
+                use numpy::IntoPyArray;
                 let arr =
                     numpy::ndarray::Array2::from_shape_vec((num_channels, num_frames), processed)
                         .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
-                Ok::<pyo3::Py<numpy::PyArray2<f32>>, PyErr>(arr.to_pyarray(py).unbind())
+                Ok::<pyo3::Py<numpy::PyArray2<f32>>, PyErr>(arr.into_pyarray(py).unbind())
             })?;
 
             Ok(result_obj)


### PR DESCRIPTION
This was something Claude noticed some time ago ... good boy!