### PR TITLE
Avoid array copies in Collector::buffer and FileAnalyzer::analyze

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -184,14 +184,24 @@ impl Collector {
         buffer: numpy::PyReadonlyArray2<'py, f32>,
         py: Python<'py>,
     ) -> PyResult<()> {
-        let array = buffer.as_array().as_standard_layout().into_owned();
+        let array = buffer.as_array();
 
         // We release the GIL here so any other Python threads get a chance to run.
         py.detach(|| {
-            // Buffer using sequential layout (channel-contiguous), matching Processor.process.
-            self.inner
-                .buffer_sequential(array.as_slice().expect("Array is in standard layout"))
-                .map_err(to_py_err)
+            // Hand the buffer straight to the layout that matches its memory order, avoiding a
+            // copy. A (channels, frames) array stored C-contiguous is channel-contiguous
+            // (sequential); stored F-contiguous it is frame-contiguous (interleaved). Only a
+            // genuinely strided view needs a normalizing copy.
+            if let Some(slice) = array.as_slice() {
+                self.inner.buffer_sequential(slice)
+            } else if let Some(slice) = array.as_slice_memory_order() {
+                self.inner.buffer_interleaved(slice)
+            } else {
+                let owned = array.as_standard_layout();
+                self.inner
+                    .buffer_sequential(owned.as_slice().expect("standard layout is contiguous"))
+            }
+            .map_err(to_py_err)
         })
     }
 }

--- a/src/file_analyzer.rs
+++ b/src/file_analyzer.rs
@@ -105,7 +105,7 @@ impl FileAnalyzer {
         step_samples: Option<usize>,
         py: Python<'py>,
     ) -> PyResult<Vec<AnalysisResult>> {
-        let audio = audio.as_array().as_standard_layout().into_owned();
+        let view = audio.as_array();
 
         let inner = &mut self.inner;
 
@@ -113,11 +113,19 @@ impl FileAnalyzer {
         // Python threads can make progress.
         let results = py
             .detach(move || {
-                inner.analyze(
-                    audio.as_slice().expect("Array is in standard layout"),
-                    sample_rate,
-                    step_samples,
-                )
+                // Pass the samples through directly when already contiguous (the common case);
+                // only a strided view needs a normalizing copy.
+                match view.as_slice() {
+                    Some(slice) => inner.analyze(slice, sample_rate, step_samples),
+                    None => {
+                        let owned = view.as_standard_layout();
+                        inner.analyze(
+                            owned.as_slice().expect("standard layout is contiguous"),
+                            sample_rate,
+                            step_samples,
+                        )
+                    }
+                }
             })
             .map_err(to_py_err)?;
 


### PR DESCRIPTION
This avoids some more copies (on top of #56) depending on the input layout.