### PR TITLE
Fail loudly when a stub anchor stops matching

### DIFF
--- a/stub-gen/src/main.rs
+++ b/stub-gen/src/main.rs
@@ -20,6 +20,31 @@ fn main() -> pyo3_stub_gen::Result<()> {
     Ok(())
 }
 
+/// Replaces `anchor`, requiring it to appear exactly `expected` times.
+///
+/// Every patch below is anchored on generated text: a method signature, or the tail of a
+/// docstring written in `src/*.rs`. A plain `str::replace` is a silent no-op when its anchor
+/// stops matching, so reworded docstring prose would drop a public method from `aic_sdk.pyi`
+/// while `cargo run -p stub-gen` still succeeded. Checking the count also keeps the anchors
+/// honest in the other direction: one that starts matching a second class would otherwise
+/// inject the same stub twice.
+fn replace_checked(
+    content: &str,
+    anchor: &str,
+    replacement: &str,
+    expected: usize,
+    what: &str,
+) -> String {
+    let found = content.matches(anchor).count();
+    assert_eq!(
+        found, expected,
+        "stub anchor for {what} matched {found} time(s), expected {expected}. The generated \
+         stub changed, so update the anchor in patch_numpy_methods (stub-gen/src/main.rs). \
+         aic_sdk.pyi has been left in its unpatched state.\nAnchor: {anchor:?}"
+    );
+    content.replace(anchor, replacement)
+}
+
 fn patch_numpy_methods(path: &std::path::Path) {
     let mut content = String::new();
     std::fs::File::open(path)
@@ -30,9 +55,12 @@ fn patch_numpy_methods(path: &std::path::Path) {
     // Add numpy imports after the existing import block.
     let numpy_imports = "import numpy as np\nimport numpy.typing as npt\n";
     let import_insertion = "import typing\n";
-    let content = content.replace(
+    let content = replace_checked(
+        &content,
         import_insertion,
         &format!("{import_insertion}{numpy_imports}"),
+        1,
+        "numpy imports",
     );
 
     // Inject process() into Processor right before get_context().
@@ -51,13 +79,16 @@ fn patch_numpy_methods(path: &std::path::Path) {
     );
     // Unique anchor: the end of Processor.initialize()'s docstring + start of get_context().
     let processor_anchor = "            >>> processor.initialize(config)\n        \"\"\"\n    def get_context(self) -> ProcessorContext:";
-    let content = content.replace(
+    let content = replace_checked(
+        &content,
         processor_anchor,
         &format!(
             "{processor_anchor_prefix}{process_stub}    def get_context(self) -> ProcessorContext:",
             processor_anchor_prefix =
                 "            >>> processor.initialize(config)\n        \"\"\"\n"
         ),
+        1,
+        "Processor.process",
     );
 
     // Inject process_async() into ProcessorAsync right before get_context().
@@ -77,20 +108,35 @@ fn patch_numpy_methods(path: &std::path::Path) {
         "        ...\n",
     );
     // Fix async return types that pyo3-stub-gen cannot infer (they return Bound<'py, PyAny>).
-    let content = content.replace(
+    // Patches both ProcessorAsync and VadAsync, whose signatures are identical.
+    let content = replace_checked(
+        &content,
         "    def initialize_async(self, config: ProcessorConfig) -> typing.Any:",
         "    def initialize_async(self, config: ProcessorConfig) -> typing.Awaitable[None]:",
+        2,
+        "initialize_async return type",
     );
 
     // Unique anchor: end of ProcessorAsync.initialize_async() docstring + start of get_context().
     let processor_async_anchor = "            >>> await processor.initialize_async(config)\n        \"\"\"\n    def get_context(self) -> ProcessorContext:";
-    let content = content.replace(
+    let content = replace_checked(
+        &content,
         processor_async_anchor,
-        &format!("{processor_async_anchor_prefix}{process_async_stub}    def get_context(self) -> ProcessorContext:", processor_async_anchor_prefix = "            >>> await processor.initialize_async(config)\n        \"\"\"\n"),
+        &format!(
+            "{processor_async_anchor_prefix}{process_async_stub}    def get_context(self) -> ProcessorContext:",
+            processor_async_anchor_prefix =
+                "            >>> await processor.initialize_async(config)\n        \"\"\"\n"
+        ),
+        1,
+        "ProcessorAsync.process_async",
     );
-    let content = content.replace(
+    // Patches both ProcessorAsync and VadAsync, whose signatures are identical.
+    let content = replace_checked(
+        &content,
         "    def terminate_session_async(self) -> typing.Any:",
         "    def terminate_session_async(self) -> typing.Awaitable[None]:",
+        2,
+        "terminate_session_async return type",
     );
 
     // Inject the NumPy methods for the dedicated synchronous and async VADs.
@@ -113,9 +159,15 @@ fn patch_numpy_methods(path: &std::path::Path) {
         "        ...\n",
     );
     let vad_anchor = "            This method allocates memory and is not real-time safe.\n        \"\"\"\n    def get_context(self) -> VadContext:";
-    let content = content.replace(
+    let content = replace_checked(
+        &content,
         vad_anchor,
-        &format!("{vad_anchor_prefix}{vad_process_stub}    def get_context(self) -> VadContext:", vad_anchor_prefix = "            This method allocates memory and is not real-time safe.\n        \"\"\"\n"),
+        &format!(
+            "{vad_anchor_prefix}{vad_process_stub}    def get_context(self) -> VadContext:",
+            vad_anchor_prefix = "            This method allocates memory and is not real-time safe.\n        \"\"\"\n"
+        ),
+        1,
+        "Vad.process",
     );
 
     let vad_process_async_stub = concat!(
@@ -132,9 +184,15 @@ fn patch_numpy_methods(path: &std::path::Path) {
         "        ...\n",
     );
     let vad_async_anchor = "        Configures the VAD asynchronously for a sample rate and block size.\n        \"\"\"\n    def get_context(self) -> VadContext:";
-    let content = content.replace(
+    let content = replace_checked(
+        &content,
         vad_async_anchor,
-        &format!("{vad_async_anchor_prefix}{vad_process_async_stub}    def get_context(self) -> VadContext:", vad_async_anchor_prefix = "        Configures the VAD asynchronously for a sample rate and block size.\n        \"\"\"\n"),
+        &format!(
+            "{vad_async_anchor_prefix}{vad_process_async_stub}    def get_context(self) -> VadContext:",
+            vad_async_anchor_prefix = "        Configures the VAD asynchronously for a sample rate and block size.\n        \"\"\"\n"
+        ),
+        1,
+        "VadAsync.process_async",
     );
 
     // Inject buffer() into Collector right after initialize().
@@ -158,9 +216,12 @@ fn patch_numpy_methods(path: &std::path::Path) {
     );
     // Unique anchor: end of Collector.initialize()'s docstring.
     let collector_anchor = "            >>> collector.initialize(config)\n        \"\"\"\n";
-    let content = content.replace(
+    let content = replace_checked(
+        &content,
         collector_anchor,
         &format!("{collector_anchor}{buffer_stub}"),
+        1,
+        "Collector.buffer",
     );
 
     // Inject analyze() into FileAnalyzer right after __new__().
@@ -204,9 +265,12 @@ fn patch_numpy_methods(path: &std::path::Path) {
     // Unique anchor: end of FileAnalyzer.__new__()'s docstring.
     let file_analyzer_anchor =
         "            >>> analyzer = aic.FileAnalyzer(model, license_key)\n        \"\"\"\n";
-    let content = content.replace(
+    let content = replace_checked(
+        &content,
         file_analyzer_anchor,
         &format!("{file_analyzer_anchor}{analyze_stub}"),
+        1,
+        "FileAnalyzer.analyze",
     );
 
     // Strip trailing whitespace from every line (ruff won't touch whitespace

--- a/stub-gen/src/main.rs
+++ b/stub-gen/src/main.rs
@@ -20,14 +20,10 @@ fn main() -> pyo3_stub_gen::Result<()> {
     Ok(())
 }
 
-/// Replaces `anchor`, requiring it to appear exactly `expected` times.
+/// Replaces every occurrence of `anchor`, asserting that there are exactly `expected`.
 ///
-/// Every patch below is anchored on generated text: a method signature, or the tail of a
-/// docstring written in `src/*.rs`. A plain `str::replace` is a silent no-op when its anchor
-/// stops matching, so reworded docstring prose would drop a public method from `aic_sdk.pyi`
-/// while `cargo run -p stub-gen` still succeeded. Checking the count also keeps the anchors
-/// honest in the other direction: one that starts matching a second class would otherwise
-/// inject the same stub twice.
+/// Stub patches rely on generated signatures and docstrings. Checking the count makes changes
+/// to those anchors fail loudly instead of silently skipping or duplicating a patch.
 fn replace_checked(
     content: &str,
     anchor: &str,


### PR DESCRIPTION
A suggested extension to ~#59~ the last release, to make sure that changing a docstring doesn't break the stub generation silently.