### PR TITLE
Release 3.1.0: update to core library 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 
 The format is inspired by Keep a Changelog, and this project adheres to semantic versioning for the Python package. The native SDK binaries are versioned independently.
 
+## 3.1.0 - 2026-08-10
+
+Update to core library version 0.23.0.
+
+### Breaking Changes
+
+#### New model file version
+
+This release requires model file version 7. Re-download your models, or the SDK will reject them
+with `ModelVersionUnsupportedError`.
+
+#### Tyto 1.0 has been replaced by Tyto 1.1
+
+The analysis model is now Tyto 1.1, `tyto-1.1-l-16khz`. Tyto 1.0 (`tyto-l-16khz`) can no longer be
+loaded by this SDK version.
+
+#### `AnalysisResult` fields changed
+
+`AnalysisResult` gained a field and lost one:
+
+- Added: `codec_degradation`, a measure of artifacts introduced by lossy speech codecs, e.g. from a
+  low bitrate or a narrowband codec.
+- Removed: `media_speech`.
+
+### Bug Fixes
+
+- `Analyzer.analyze_buffered()` no longer crashes when OpenTelemetry reporting is enabled.
+
 ## 3.0.0 - 2026-08-06
 
 Update to core library version 0.22.0.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aic-model-downloader"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9d349fb591ef7638faa3de5b79b9a4ac6f5fe5f04a81c3ad9fb16fa1e5f410"
+checksum = "772ce9b0efe768204f776ea0aab418fce46356db645572884c4febb817e721ab"
 dependencies = [
  "serde",
  "serde_json",
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "aic-sdk"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b55f66b9a2f009e816fcf1d9d97580b18ac2b2a883efc8ef5c37ff8291f66e"
+checksum = "a6754f04de83b6d029c6ada4de779e13ea05b1a99d71d6512ba3136281f4b85d"
 dependencies = [
  "aic-model-downloader",
  "aic-sdk-sys",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "aic-sdk-py"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "aic-sdk",
  "numpy",
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "aic-sdk-sys"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0970f9ac3271532df57f4498b7730a331b4e0060eb22bde940fa4db25a245db"
+checksum = "a421512f2d6de08d7d1962be494f70e70fa4bf986fb0fefac443c8430d206de7"
 dependencies = [
  "bindgen",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["stub-gen"]
 edition = "2024"
 name = "aic-sdk-py"
 rust-version = "1.88"
-version = "3.0.0"
+version = "3.1.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -15,7 +15,7 @@ name = "aic_sdk"
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-aic-sdk = { version = "0.22.0", features = ["async", "download-lib", "download-model"] }
+aic-sdk = { version = "0.23.0", features = ["async", "download-lib", "download-model"] }
 numpy = "0.27"
 pyo3 = { version = "0.27", features = ["generate-import-lib", "multiple-pymethods"] }
 pyo3-async-runtimes = { version = "0.27", features = ["tokio-runtime"] }

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ The analysis API runs the *Tyto* analysis model to score audio quality, predicti
 of failure of downstream models (speech-to-text, VAD, turn-taking, speech-to-speech). Each
 `AnalysisResult` exposes seven scores in the `0.0`–`1.0` range (lower is less problematic, except
 `speaker_loudness`): `risk_score`, `speaker_reverb`, `speaker_loudness`, `interfering_speech`,
-`media_speech`, `noise`, and `packet_loss`.
+`noise`, `codec_degradation`, and `packet_loss`.
 
 #### Whole-file analysis
 
@@ -272,7 +272,7 @@ import numpy as np
 import aic_sdk as aic
 
 # Use an analysis model (Tyto), not an enhancement model.
-model = aic.Model.from_file(aic.Model.download("tyto-l-16khz", "./models"))
+model = aic.Model.from_file(aic.Model.download("tyto-1.1-l-16khz", "./models"))
 analyzer = aic.FileAnalyzer(model, license_key)
 
 # audio: 1D mono float32 NumPy array

--- a/aic_sdk.pyi
+++ b/aic_sdk.pyi
@@ -92,18 +92,18 @@ class AnalysisResult:
         Range: 0.0 to 1.0
         """
     @property
-    def media_speech(self) -> builtins.float:
+    def noise(self) -> builtins.float:
         r"""
-        Measure of interfering speech content from media devices,
-        e.g. from TVs, radios, phones or else.
+        Measure of ambient or environmental noise.
         Lower indicates less problematic audio.
 
         Range: 0.0 to 1.0
         """
     @property
-    def noise(self) -> builtins.float:
+    def codec_degradation(self) -> builtins.float:
         r"""
-        Measure of ambient or environmental noise.
+        Measure of artifacts introduced by lossy speech codecs,
+        e.g. from a low bitrate or a narrowband codec.
         Lower indicates less problematic audio.
 
         Range: 0.0 to 1.0

--- a/examples/analyze_file.py
+++ b/examples/analyze_file.py
@@ -22,7 +22,7 @@ import soundfile as sf
 
 import aic_sdk as aic
 
-MODEL = "tyto-l-16khz"
+MODEL = "tyto-1.1-l-16khz"
 STEP_SECONDS = 5
 
 
@@ -61,7 +61,7 @@ def main():
     results = analyzer.analyze(samples, sample_rate, step_samples)
 
     print()
-    print(" time | risk  | reverb | loud  | intf  | media | noise | loss")
+    print(" time | risk  | reverb | loud  | intf  | noise | codec | loss")
     print("------+-------+--------+-------+-------+-------+-------+------")
     for index, result in enumerate(results):
         print(
@@ -70,8 +70,8 @@ def main():
             f"{result.speaker_reverb:>6.3f} | "
             f"{result.speaker_loudness:>5.3f} | "
             f"{result.interfering_speech:>5.3f} | "
-            f"{result.media_speech:>5.3f} | "
             f"{result.noise:>5.3f} | "
+            f"{result.codec_degradation:>5.3f} | "
             f"{result.packet_loss:>4.3f}"
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license = { file = "LICENSE" }
 name = "aic-sdk"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "3.0.0"
+version = "3.1.0"
 
 [dependency-groups]
 dev = ["pytest-asyncio>=1.3.0", "pytest>=9.0.2"]

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -35,17 +35,17 @@ pub struct AnalysisResult {
     ///
     /// Range: 0.0 to 1.0
     pub interfering_speech: f32,
-    /// Measure of interfering speech content from media devices,
-    /// e.g. from TVs, radios, phones or else.
-    /// Lower indicates less problematic audio.
-    ///
-    /// Range: 0.0 to 1.0
-    pub media_speech: f32,
     /// Measure of ambient or environmental noise.
     /// Lower indicates less problematic audio.
     ///
     /// Range: 0.0 to 1.0
     pub noise: f32,
+    /// Measure of artifacts introduced by lossy speech codecs,
+    /// e.g. from a low bitrate or a narrowband codec.
+    /// Lower indicates less problematic audio.
+    ///
+    /// Range: 0.0 to 1.0
+    pub codec_degradation: f32,
     /// Measure of audio dropouts or discontinuities in the stream,
     /// e.g. from packet loss, frame erasure, jitter or CPU overload.
     /// Lower indicates less problematic audio.
@@ -60,13 +60,13 @@ impl AnalysisResult {
     fn __repr__(&self) -> String {
         format!(
             "AnalysisResult(risk_score={}, speaker_reverb={}, speaker_loudness={}, \
-             interfering_speech={}, media_speech={}, noise={}, packet_loss={})",
+             interfering_speech={}, noise={}, codec_degradation={}, packet_loss={})",
             self.risk_score,
             self.speaker_reverb,
             self.speaker_loudness,
             self.interfering_speech,
-            self.media_speech,
             self.noise,
+            self.codec_degradation,
             self.packet_loss,
         )
     }
@@ -79,8 +79,8 @@ impl From<aic_sdk::AnalysisResult> for AnalysisResult {
             speaker_reverb: value.speaker_reverb,
             speaker_loudness: value.speaker_loudness,
             interfering_speech: value.interfering_speech,
-            media_speech: value.media_speech,
             noise: value.noise,
+            codec_degradation: value.codec_degradation,
             packet_loss: value.packet_loss,
         }
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def vad_model():
 @pytest.fixture
 def analysis_model():
     # The analyzer requires an analysis model (Tyto), not an enhancement model.
-    model_id = "tyto-l-16khz"
+    model_id = "tyto-1.1-l-16khz"
     model_path = aic.Model.download(model_id, "./models")
     return aic.Model.from_file(model_path)
 

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -8,8 +8,8 @@ _SCORE_ATTRS = (
     "speaker_reverb",
     "speaker_loudness",
     "interfering_speech",
-    "media_speech",
     "noise",
+    "codec_degradation",
     "packet_loss",
 )
 
@@ -96,7 +96,7 @@ def test_analyzer_pair_keeps_model_alive_after_model_drop(license_key):
     # Create the model locally so the returned pair holds the only remaining reference once we
     # drop ours. The collector/analyzer must keep the native model state alive; otherwise the
     # analyze_buffered() below would use freed memory.
-    model = aic.Model.from_file(aic.Model.download("tyto-l-16khz", "./models"))
+    model = aic.Model.from_file(aic.Model.download("tyto-1.1-l-16khz", "./models"))
     collector, analyzer = make_pair_or_skip(model, license_key)
     config = aic.ProcessorConfig.optimal(model)
 

--- a/tests/test_file_analyzer.py
+++ b/tests/test_file_analyzer.py
@@ -10,8 +10,8 @@ _SCORE_ATTRS = (
     "speaker_reverb",
     "speaker_loudness",
     "interfering_speech",
-    "media_speech",
     "noise",
+    "codec_degradation",
     "packet_loss",
 )
 

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "aic-sdk"
-version = "3.0.0"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary
- Bumps the `aic-sdk` Rust dependency from 0.22.0 to 0.23.0.
- Analysis model updated: Tyto 1.0 (`tyto-l-16khz`) is replaced by Tyto 1.1 (`tyto-1.1-l-16khz`) throughout the README, examples, and tests.
- `AnalysisResult` field change to match the new core library: removed `media_speech`, added `codec_degradation`.
- Requires model file version 7 (re-download models built for earlier SDK versions or they'll be rejected with `ModelVersionUnsupportedError`).
- Bumps package version 3.0.0 -> 3.1.0 (`pyproject.toml`, `Cargo.toml`) since the `AnalysisResult` field change is breaking; `CHANGELOG.md` updated accordingly.
- Regenerated `aic_sdk.pyi` via `make stubs`.

## Test plan
- [x] `cargo build -p aic-sdk-py`
- [x] `make stubs` (regenerates `aic_sdk.pyi` cleanly)
- [x] `uvx ruff check examples tests`
- [x] `pytest --collect-only` (199 tests collected)
- [ ] Full `pytest` run against a real license key and re-downloaded models (needs `AIC_SDK_LICENSE`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)