### PR TITLE
Release 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is inspired by Keep a Changelog, and this project adheres to semantic versioning for the Python package. The native SDK binaries are versioned independently.
 
+## 3.2.0 - 2026-09-07
+
+Update to core library version 0.24.0.
+
+### New Features
+
+#### SDK-internal error reporting
+
+The SDK reports its own backend failures to ai-coustics error tracking. Covered are failed session
+activations, failed usage reports, and bearer token refreshes rejected by
+`ProcessorContext.update_bearer_token()`, `VadContext.update_bearer_token()` and `Analyzer.update_bearer_token()`.
+
+A report contains the error class and message, the SDK version and wrapper, the model ID, the
+operating system, the CPU architecture, and the account the license was issued to. It contains no
+audio, no license key and no bearer token.
+
+Disable reporting with `DO_NOT_TRACK=1`. The variable is read once per process.
+Licenses with an offline entitlement never report.
+
 ## 3.1.1 - 2026-09-07
 
 Update to core library version 0.23.1.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "aic-model-downloader"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03453b43c8506088b4c777021b67609a0d3beaed9092e43d6de6d18b2f8fc693"
+checksum = "05a0a939f48d83cf9d1f11b3606df0914967e80b7dc9942a87db4d734847dee1"
 dependencies = [
  "serde",
  "serde_json",
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "aic-sdk"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722e5cde0ea57b74b13809bae34721b22f487a3e797cad168c094ff325d55ed2"
+checksum = "41af1bb1ff01e573b683d6a7ae68af32a5c1efad4056019828c3e8d61f0695ee"
 dependencies = [
  "aic-model-downloader",
  "aic-sdk-sys",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "aic-sdk-py"
-version = "3.1.1"
+version = "3.2.0"
 dependencies = [
  "aic-sdk",
  "numpy",
@@ -59,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "aic-sdk-sys"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8287759ce2c94bd1da7848a639b15c3204fc7d4e0135534fd28c6363b9c1e7b1"
+checksum = "bc9a207d4352a0d09a8e36c021675b6896ecd78b58b01d180c0841c6c84d7f96"
 dependencies = [
  "bindgen",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["stub-gen"]
 edition = "2024"
 name = "aic-sdk-py"
 rust-version = "1.88"
-version = "3.1.1"
+version = "3.2.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -15,7 +15,7 @@ name = "aic_sdk"
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-aic-sdk = { version = "0.23.1", features = ["async", "download-lib", "download-model"] }
+aic-sdk = { version = "0.24.0", features = ["async", "download-lib", "download-model"] }
 numpy = "0.27"
 pyo3 = { version = "0.27", features = ["generate-import-lib", "multiple-pymethods"] }
 pyo3-async-runtimes = { version = "0.27", features = ["tokio-runtime"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license = { file = "LICENSE" }
 name = "aic-sdk"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "3.1.1"
+version = "3.2.0"
 
 [dependency-groups]
 dev = ["pytest-asyncio>=1.3.0", "pytest>=9.0.2"]

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "aic-sdk"
-version = "3.1.1"
+version = "3.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Update to core library version 0.24.0.

### New Features

#### SDK-internal error reporting

The SDK reports its own backend failures to ai-coustics error tracking. Covered are failed session
activations, failed usage reports, and bearer token refreshes rejected by
`ProcessorContext.update_bearer_token()`, `VadContext.update_bearer_token()` and `Analyzer.update_bearer_token()`.

A report contains the error class and message, the SDK version and wrapper, the model ID, the
operating system, the CPU architecture, and the account the license was issued to. It contains no
audio, no license key and no bearer token.

Disable reporting with `DO_NOT_TRACK=1`. The variable is read once per process.
Licenses with an offline entitlement never report.