### PR TITLE
Link the SDK binary license to the ai-coustics legal pages

### DIFF
--- a/LICENSE.AIC-SDK
+++ b/LICENSE.AIC-SDK
@@ -1,74 +1,17 @@
-AIC-SDK BINARY LICENSE AGREEMENT
-Version 1.0 — 25 July 2025
-Copyright © 2025 ai-coustics GmbH. All rights reserved.
+AIC SDK BINARY LICENSE
 
-0.  Definitions
-    “SDK”       means the files distributed inside the `aic-sdk-c` folder
-                aic-sdk-c/libs/* (e.g. libaic.a, libaic.so, libaic.dylib, aic.dll)
-                together with the public C header aic.h.
-    “Wrapper”   means the source code in this repository that links to
-                the SDK. The Wrapper is licensed separately under the
-                Apache-2.0 license found in LICENSE.
-    “You”       means the individual or legal entity exercising rights under
-                this Agreement.
+The ai-coustics SDK binary (libaic, distributed as libaic.a, libaic.so,
+libaic.dylib or aic.dll together with the aic.h header) and the ai-coustics
+models are proprietary software of ai-coustics GmbH. They are not covered by
+the Apache-2.0 license in LICENSE, which applies only to the Python wrapper source
+code in this repository.
 
-1.  License Grant
-    Subject to the terms below, ai|coustics GmbH (“Licensor”) grants You a
-    non-exclusive, non-transferable, worldwide, royalty-free right to
-    (a) install and use the SDK **in object-code form only** together with
-        the Wrapper, in products and services that You develop or operate;
-    (b) reproduce and redistribute the unmodified SDK solely when it is
-        embedded in an application that **depends on the Wrapper**, provided
-        that You
-        • include this license file with your distribution, and
-        • do not charge a fee specifically for the SDK.
+Your use of the SDK binary and the models is governed by:
 
-2.  Restrictions
-    You shall not, and shall not allow any third party to:
-    • modify, translate, reverse-engineer, decompile, disassemble or
-      otherwise attempt to derive the source code of the SDK (except to the
-      limited extent such actions are expressly permitted by mandatory law);
-    • remove or obscure any proprietary notices;
-    • use the SDK to create or train competing speech-enhancement models;
-    • redistribute the SDK as a stand-alone product, via package registries
-      (PyPI, npm, crates.io, etc.), or in any manner that allows third
-      parties to access the SDK separate from Your application.
+  ai-coustics Terms of Service   https://ai-coustics.com/legal/terms
+  ai-coustics Model License      https://ai-coustics.com/legal/model-license
 
-3.  Proprietary Rights
-    Title to, and all intellectual-property rights in, the SDK remain with
-    Licensor and its licensors.  No rights are granted to You except as
-    expressly set out herein.
+By downloading, installing or using the SDK binary or the models you agree to
+these terms.
 
-4.  Warranty Disclaimer
-    THE SDK IS PROVIDED “AS IS” WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
-
-5.  Limitation of Liability
-    TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL
-    LICENSOR BE LIABLE FOR ANY INDIRECT, SPECIAL, INCIDENTAL OR
-    CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
-    SDK, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.  LICENSOR’S
-    TOTAL CUMULATIVE LIABILITY SHALL NOT EXCEED EUR 500.
-
-6.  Termination
-    This Agreement terminates automatically if You breach any term hereof.
-    Upon termination, You must cease all use and destroy all copies of the
-    SDK in your possession.  Sections 3–7 survive termination.
-
-7.  Governing Law and Venue
-    This Agreement is governed by the laws of Germany.  Exclusive venue for
-    any dispute shall be the courts of Berlin, Germany.
-
-8.  Third-Party Code
-    The SDK may contain or link to third-party components that are subject
-    to separate open-source licenses. Such components remain governed by
-    their respective terms.
-
-9.  Entire Agreement
-    This document constitutes the entire agreement between Licensor and You
-    regarding the SDK and supersedes all prior oral or written agreements.
-
-By installing, copying or otherwise using the SDK You acknowledge that
-You have read this Agreement, understand it, and agree to be bound by its
-terms.
+Copyright (c) ai-coustics GmbH. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -366,4 +366,7 @@ For a benchmarking example that tests how many concurrent processing sessions yo
 
 ## License
 
-This Python wrapper is distributed under the Apache 2.0 license. The core C SDK is distributed under the proprietary AIC-SDK license.
+This Python wrapper is distributed under the Apache 2.0 license (`LICENSE`). The core SDK binary and
+the models are proprietary and governed by the ai-coustics
+[Terms of Service](https://ai-coustics.com/legal/terms) and
+[Model License](https://ai-coustics.com/legal/model-license); see `LICENSE.AIC-SDK`.


### PR DESCRIPTION
The proprietary SDK binary is no longer licensed by a license text kept in this repo. ``LICENSE.AIC-SDK`` now links to the ai-coustics legal pages instead:

- Terms of Service: https://ai-coustics.com/legal/terms
- Model License: https://ai-coustics.com/legal/model-license

The wrapper itself stays Apache-2.0. The README license section is updated to match.
